### PR TITLE
allow not to build a specific path for default language fixes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,51 @@ site
     └── index.html
 ```
 
+### Not building a dedicated version for the default language
+
+If you do not wish to build a dedicated `<language>/` path for the `default_language` version of your documentation, **simply do not list it on the `languages`** list. See issue #5 for more information.
+
+The following configuration:
+
+```
+plugins:
+  - i18n:
+      default_language: en
+      languages:
+        fr: français
+```
+
+Applied on the following structure:
+
+```
+docs
+├── index.fr.md
+├── index.md
+├── topic1
+│   ├── index.en.md
+│   └── index.fr.md
+└── topic2
+    ├── index.en.md
+    └── index.md
+```
+
+Will build:
+
+```
+site
+├── fr
+│   ├── index.html
+│   ├── topic1
+│   │   └── index.html
+│   └── topic2
+│       └── index.html
+├── index.html
+├── topic1
+│   └── index.html
+└── topic2
+    └── index.html
+```
+
 ## Compatibility with other plugins
 
 This plugin is compatible with the following mkdocs plugins:

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -74,7 +74,7 @@ class I18n(BasePlugin):
         i18n_page = deepcopy(page)
 
         # there is a specific translation file for this lang
-        for lang in self.config["languages"]:
+        for lang in self.all_languages:
             if self._is_translation_for(i18n_page.src_path, lang):
                 i18n_page.name = page.name.replace(f".{lang}", "")
                 if config.get("use_directory_urls") is False:
@@ -125,7 +125,7 @@ class I18n(BasePlugin):
         return i18n_page
 
     def _get_page_lang(self, page):
-        for language in self.config.get("languages"):
+        for language in self.all_languages:
             if Path(page.src_path).suffixes == [f".{language}", ".md"]:
                 return language
         return None
@@ -150,16 +150,16 @@ class I18n(BasePlugin):
             return files
 
         default_language = self.config.get("default_language")
-        languages = self.config.get("languages")
+        self.all_languages = set([default_language] + list(self.config["languages"]))
 
         main_files = Files([])
-        for language in languages:
+        for language in self.all_languages:
             self.i18n_files[language] = Files([])
 
         for obj in files:
             if obj not in files.documentation_pages():
                 main_files.append(obj)
-                for language in languages:
+                for language in self.all_languages:
                     self.i18n_files[language].append(obj)
 
         base_paths = set()
@@ -188,7 +188,7 @@ class I18n(BasePlugin):
                     self._get_non_translated_page(main_page, page_lang, config)
                 )
 
-            for language in languages:
+            for language in self.all_languages:
                 lang_expects = [
                     base_path.with_suffix(f".{language}.md"),
                     base_path.with_suffix(f".{default_language}.md"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,3 +14,9 @@ def config_base():
 def config_plugin():
     site_dir = tempfile.mkdtemp(prefix="mkdocs_tests_")
     return load_config("tests/mkdocs_i18n.yml", site_dir=site_dir)
+
+
+@pytest.fixture
+def config_plugin_no_default_language():
+    site_dir = tempfile.mkdtemp(prefix="mkdocs_tests_")
+    return load_config("tests/mkdocs_i18n_no_default_language.yml", site_dir=site_dir)

--- a/tests/mkdocs_i18n_no_default_language.yml
+++ b/tests/mkdocs_i18n_no_default_language.yml
@@ -1,0 +1,7 @@
+site_name: MkDocs static i18n plugin tests without default language build
+
+plugins:
+  - i18n:
+      default_language: en
+      languages:
+        fr: français

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -42,6 +42,25 @@ PLUGIN_NO_USE_DIRECTORY_URLS = [
     "fr/folder/toto.html",
 ]
 
+PLUGIN_USE_DIRECTORY_URLS_NO_DEFAULT = [
+    "404.html",
+    "index.html",
+    "folder/tata/index.html",
+    "folder/toto/index.html",
+    "fr/index.html",
+    "fr/folder/tata/index.html",
+    "fr/folder/toto/index.html",
+]
+PLUGIN_NO_USE_DIRECTORY_URLS_NO_DEFAULT = [
+    "404.html",
+    "test.html",
+    "folder/tata.html",
+    "folder/toto.html",
+    "fr/test.html",
+    "fr/folder/tata.html",
+    "fr/folder/toto.html",
+]
+
 
 def test_build_use_directory_urls(config_base):
     config_base["use_directory_urls"] = True
@@ -81,3 +100,27 @@ def test_plugin_no_use_directory_urls(config_plugin):
         f.relative_to(site_dir).as_posix() for f in Path(site_dir).glob("**/*.html")
     ]
     assert sorted(generated_html) == sorted(PLUGIN_NO_USE_DIRECTORY_URLS)
+
+
+def test_plugin_use_directory_urls_no_default_language(
+    config_plugin_no_default_language,
+):
+    config_plugin_no_default_language["use_directory_urls"] = True
+    site_dir = config_plugin_no_default_language["site_dir"]
+    build(config_plugin_no_default_language)
+    generated_html = [
+        f.relative_to(site_dir).as_posix() for f in Path(site_dir).glob("**/*.html")
+    ]
+    assert sorted(generated_html) == sorted(PLUGIN_USE_DIRECTORY_URLS_NO_DEFAULT)
+
+
+def test_plugin_no_use_directory_urls_no_default_language(
+    config_plugin_no_default_language,
+):
+    config_plugin_no_default_language["use_directory_urls"] = False
+    site_dir = config_plugin_no_default_language["site_dir"]
+    build(config_plugin_no_default_language)
+    generated_html = [
+        f.relative_to(site_dir).as_posix() for f in Path(site_dir).glob("**/*.html")
+    ]
+    assert sorted(generated_html) == sorted(PLUGIN_NO_USE_DIRECTORY_URLS_NO_DEFAULT)


### PR DESCRIPTION
you might want not to build a specific <language>/ path for the
default_language

this commits will make it so that we only build <language>/ paths
for the languages specified in the languages map