### PR TITLE
add support for mkdocs search plugin closes #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,18 +208,18 @@ If you enabled the `search` plugin embedded with MkDocs, this plugin will
 automatically populate its `lang` option with the the configured `languages`
 as long as they are supported by [lunr](https://pypi.org/project/lunr/).
 
-!!! warning
-    Search results will include all the pages from all the localized contents.
+:warning: **Search results will include all the pages from all the localized
+contents!**
 
-    This means that your search results can't be contextual to the language
-    you are currently browsing.
+This means that your search results can't be contextual to the language
+you are currently browsing.
 
-    The `mkdocs-static-i18n` plugin will try to be smart and deduplicate the
-    pages from the `default_language` so that search results are not polluted.
+The `mkdocs-static-i18n` plugin will try to be smart and deduplicate the
+pages from the `default_language` so that search results are not polluted.
 
-    This is because the MkDocs `search` plugin is hardcoded in the themes
-    javascript sources so there can only be one search index for the whole
-    build.
+This is because the MkDocs `search` plugin is hardcoded in the themes
+javascript sources so there can only be one search index for the whole
+build.
 
 ## Compatibility with other plugins
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,25 @@ plugins:
           Topic2: Sujet2
 ```
 
+## Compatibility with the search plugin
+
+If you enabled the `search` plugin embedded with MkDocs, this plugin will
+automatically populate its `lang` option with the the configured `languages`
+as long as they are supported by [lunr](https://pypi.org/project/lunr/).
+
+!!! warning
+    Search results will include all the pages from all the localized contents.
+
+    This means that your search results can't be contextual to the language
+    you are currently browsing.
+
+    The `mkdocs-static-i18n` plugin will try to be smart and deduplicate the
+    pages from the `default_language` so that search results are not polluted.
+
+    This is because the MkDocs `search` plugin is hardcoded in the themes
+    javascript sources so there can only be one search index for the whole
+    build.
+
 ## Compatibility with other plugins
 
 This plugin is compatible with the following mkdocs plugins:

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -208,7 +208,7 @@ class I18n(BasePlugin):
                 i18n_page.abs_dest_path = i18n_page.abs_dest_path.parent.with_suffix(
                     ".html"
                 )
-                i18n_page.url = str(Path(i18n_page.dest_path).parent.as_posix())
+                i18n_page.url = str(Path(i18n_page.dest_path).parent.as_posix()) + "/"
 
             else:
                 i18n_page.dest_path = i18n_page.dest_path.parent.with_suffix(
@@ -217,7 +217,7 @@ class I18n(BasePlugin):
                 i18n_page.abs_dest_path = i18n_page.abs_dest_path.parent.with_suffix(
                     ""
                 ).joinpath(i18n_page.abs_dest_path.name)
-                i18n_page.url = str(Path(i18n_page.dest_path).parent.as_posix())
+                i18n_page.url = str(Path(i18n_page.dest_path).parent.as_posix()) + "/"
 
         return i18n_page
 

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -31,6 +31,28 @@ except Exception:
 
 log = logging.getLogger("mkdocs.plugins." + __name__)
 
+LUNR_LANGUAGES = [
+    "ar",
+    "da",
+    "de",
+    "en",
+    "es",
+    "fi",
+    "fr",
+    "hu",
+    "it",
+    "ja",
+    "nl",
+    "no",
+    "pt",
+    "ro",
+    "ru",
+    "sv",
+    "th",
+    "tr",
+    "vi",
+]
+
 
 class Locale(Type):
     """
@@ -322,6 +344,21 @@ class I18n(BasePlugin):
                                 "lang": language,
                             }
                         )
+        # Support for the search plugin lang
+        if "search" in config["plugins"]:
+            search_langs = config["plugins"]["search"].config["lang"] or []
+            for language in self.all_languages:
+                if language in LUNR_LANGUAGES:
+                    if language not in search_langs:
+                        search_langs.append(language)
+                        log.info(
+                            f"Adding '{language}' to the 'plugins.search.lang' option"
+                        )
+                else:
+                    log.warning(
+                        f"Language '{language}' is not supported by "
+                        f"lunr.js, not setting it in the 'plugins.search.lang' option"
+                    )
         return config
 
     def on_files(self, files, config):
@@ -337,6 +374,12 @@ class I18n(BasePlugin):
             self.i18n_files[language] = I18nFiles([])
             self.i18n_files[language].default_locale = self.default_language
             self.i18n_files[language].locale = language
+            # there can be only one instance of the search plugin because
+            # it is hardcoded in the JS worker sources
+            if "search" in config["plugins"]:
+                self.i18n_configs[language]["plugins"]["search"] = config["plugins"][
+                    "search"
+                ]
 
         base_paths = set()
         for fileobj in files:
@@ -440,6 +483,28 @@ class I18n(BasePlugin):
             files.translated = True
         return nav
 
+    def _fix_search_duplicates(self, language, search_plugin):
+        """
+        We want to avoid indexing the same pages twice if the default language
+        has its own version built as well as the /language version too as this
+        would pollute the search results.
+
+        When this happens, we favor the default language location if its
+        content is the same as its /language counterpart.
+        """
+        entries = deepcopy(search_plugin.search_index._entries)
+        for entry in entries:
+            if entry["location"].startswith(f"{language}/"):
+                for s_entry in search_plugin.search_index._entries:
+                    expected_locations = [
+                        f"{language}/{s_entry['location']}",
+                        f"{language}/{s_entry['location'].rstrip('/')}",
+                        f"{language}/{s_entry['location'].replace('/#', '#')}",
+                    ]
+                    if entry["location"] in expected_locations:
+                        if entry["text"] == s_entry["text"]:
+                            search_plugin.search_index._entries.remove(entry)
+
     def on_post_build(self, config):
         """
         Derived from mkdocs commands build function.
@@ -447,6 +512,7 @@ class I18n(BasePlugin):
         We build every language on its own directory.
         """
         dirty = False
+        search_plugin = config["plugins"].get("search")
         for language in self.config.get("languages"):
             log.info(f"Building {language} documentation")
 
@@ -462,7 +528,11 @@ class I18n(BasePlugin):
             files = self.i18n_files[language]
             nav = self.i18n_navs[language]
 
-            # Support mkdocs-material i18n search context
+            # TODO: check if messing with site_dir wouldn't be easier than
+            # changing file dest_paths etc
+            # config["site_dir"] += "/fr"
+
+            # Support mkdocs-material theme language
             if config["theme"].name == "material":
                 if language in material_languages:
                     config["theme"].language = language
@@ -483,5 +553,14 @@ class I18n(BasePlugin):
             for file in files.documentation_pages():
                 _populate_page(file.page, config, files, dirty)
 
-            for file in self.i18n_files[language].documentation_pages():
+            for file in files.documentation_pages():
                 _build_page(file.page, config, files, nav, env, dirty)
+
+            # Update the search plugin index with language pages
+            if search_plugin:
+                if (
+                    language == self.default_language
+                    and self.default_language in self.config["languages"]
+                ):
+                    self._fix_search_duplicates(language, search_plugin)
+                search_plugin.on_post_build(config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,3 +46,13 @@ def config_plugin_translated_nav():
             docs_dir="../docs/",
             site_dir=site_dir,
         )
+
+
+@pytest.fixture
+def config_plugin_search():
+    with tempfile.TemporaryDirectory(prefix="mkdocs_tests_") as site_dir:
+        return load_config(
+            "tests/mkdocs_i18n_search.yml",
+            docs_dir="../docs/",
+            site_dir=site_dir,
+        )

--- a/tests/mkdocs_base.yml
+++ b/tests/mkdocs_base.yml
@@ -1,1 +1,2 @@
 site_name: MkDocs static i18n plugin tests
+site_url: http://localhost

--- a/tests/mkdocs_i18n.yml
+++ b/tests/mkdocs_i18n.yml
@@ -1,4 +1,5 @@
 site_name: MkDocs static i18n plugin tests
+site_url: http://localhost
 
 plugins:
   - i18n:

--- a/tests/mkdocs_i18n_search.yml
+++ b/tests/mkdocs_i18n_search.yml
@@ -1,8 +1,10 @@
-site_name: MkDocs static i18n plugin tests without default language build
+site_name: MkDocs static i18n plugin tests
 site_url: http://localhost
 
 plugins:
+  - search
   - i18n:
       default_language: en
       languages:
+        en: english
         fr: français

--- a/tests/mkdocs_i18n_static_nav.yml
+++ b/tests/mkdocs_i18n_static_nav.yml
@@ -1,4 +1,5 @@
 site_name: MkDocs static i18n plugin tests with static nav
+site_url: http://localhost
 
 nav:
   - Home: index.md

--- a/tests/mkdocs_i18n_translated_nav.yml
+++ b/tests/mkdocs_i18n_translated_nav.yml
@@ -1,4 +1,5 @@
 site_name: MkDocs static i18n plugin tests with static nav
+site_url: http://localhost
 
 nav:
   - Home: index.md

--- a/tests/test_language_selector.py
+++ b/tests/test_language_selector.py
@@ -23,6 +23,7 @@ def test_plugin_language_selector_use_directory_urls():
         theme={"name": "mkdocs"},
         use_directory_urls=True,
         docs_dir="../docs/",
+        site_url="http://localhost",
         extra_javascript=[],
     )
     result = plugin.on_config(config, force=True)
@@ -39,6 +40,7 @@ def test_plugin_language_selector_no_use_directory_urls():
         theme={"name": "mkdocs"},
         use_directory_urls=False,
         docs_dir="../docs/",
+        site_url="http://localhost",
         extra_javascript=[],
     )
     result = plugin.on_config(config, force=True)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,40 @@
+from mkdocs.commands.build import build
+
+
+def test_search_add_lang(config_plugin_search):
+    config = config_plugin_search
+    build(config)
+    search_plugin = config["plugins"]["search"]
+    assert search_plugin.config["lang"] == ["en", "fr"]
+
+
+def test_search_entries(config_plugin_search):
+    config = config_plugin_search
+    config["plugins"]["i18n"].config["languages"] = {"fr": "français"}
+    build(config)
+    search_plugin = config["plugins"]["search"]
+    assert len(search_plugin.search_index._entries) == 30
+
+
+def test_search_entries_no_directory_urls(config_plugin_search):
+    config = config_plugin_search
+    config["use_directory_urls"] = False
+    config["plugins"]["i18n"].config["languages"] = {"fr": "français"}
+    build(config)
+    search_plugin = config["plugins"]["search"]
+    assert len(search_plugin.search_index._entries) == 30
+
+
+def test_search_deduplicate_entries(config_plugin_search):
+    config = config_plugin_search
+    build(config)
+    search_plugin = config["plugins"]["search"]
+    assert len(search_plugin.search_index._entries) == 33
+
+
+def test_search_deduplicate_entries_no_directory_urls(config_plugin_search):
+    config = config_plugin_search
+    config["use_directory_urls"] = False
+    build(config)
+    search_plugin = config["plugins"]["search"]
+    assert len(search_plugin.search_index._entries) == 33

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,35 @@
+from mkdocs.structure.files import get_files
+
+
+def test_urls_no_use_directory_urls(config_base, config_plugin):
+    config_base["use_directory_urls"] = False
+    files = get_files(config_base)
+    #
+    config_plugin["use_directory_urls"] = False
+    i18n_plugin = config_plugin["plugins"]["i18n"]
+    #
+    i18n_plugin.on_config(config_plugin)
+    i18n_files = i18n_plugin.on_files(get_files(config_plugin), config_plugin)
+    #
+    mkdocs_urls = {p.url[-1] for p in files.documentation_pages()}
+    plugin_urls = {p.url[-1] for p in i18n_files.documentation_pages()}
+    print({p.url for p in files.documentation_pages()})
+    print({p.url for p in i18n_files.documentation_pages()})
+    assert mkdocs_urls == plugin_urls
+
+
+def test_urls_use_directory_urls(config_base, config_plugin):
+    config_base["use_directory_urls"] = True
+    files = get_files(config_base)
+    #
+    config_plugin["use_directory_urls"] = True
+    i18n_plugin = config_plugin["plugins"]["i18n"]
+    #
+    i18n_plugin.on_config(config_plugin)
+    i18n_files = i18n_plugin.on_files(get_files(config_plugin), config_plugin)
+    #
+    mkdocs_urls = {p.url[-1] for p in files.documentation_pages()}
+    plugin_urls = {p.url[-1] for p in i18n_files.documentation_pages()}
+    print({p.url for p in files.documentation_pages()})
+    print({p.url for p in i18n_files.documentation_pages()})
+    assert mkdocs_urls == plugin_urls


### PR DESCRIPTION
Search results will include all the pages from all the localized contents.

This means that your search results can't be contextual to the language
you are currently browsing.

The `mkdocs-static-i18n` plugin will try to be smart and deduplicate the
pages from the `default_language` so that search results are not polluted.

This is because the MkDocs `search` plugin is hardcoded in the themes
javascript sources so there can only be one search index for the whole
build.