### PR TITLE
Compatible with mkdocs-with-pdf plugin

### DIFF
--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -118,8 +118,6 @@ class I18n(BasePlugin):
         """
         Enrich configuration with language specific knowledge.
         """
-        if "skip_i18n" in config:
-            return
         self.default_language = self.config["default_language"]
         # Make a order preserving list of all the configured
         # languages, add the default one first if not listed by the user
@@ -458,7 +456,7 @@ class I18n(BasePlugin):
         We build every language on its own directory.
         """
         # skip language builds requested?
-        if self.config["default_language_only"] is True or "skip_i18n" in config:
+        if self.config["default_language_only"] is True:
             return
 
         dirty = False

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -118,7 +118,8 @@ class I18n(BasePlugin):
         """
         Enrich configuration with language specific knowledge.
         """
-        if 'skip_i18n' in config: return
+        if "skip_i18n" in config:
+            return
         self.default_language = self.config["default_language"]
         # Make a order preserving list of all the configured
         # languages, add the default one first if not listed by the user
@@ -432,7 +433,7 @@ class I18n(BasePlugin):
         We build every language on its own directory.
         """
         # skip language builds requested?
-        if self.config["default_language_only"] is True or 'skip_i18n' in config:
+        if self.config["default_language_only"] is True or "skip_i18n" in config:
             return
 
         dirty = False
@@ -468,8 +469,10 @@ class I18n(BasePlugin):
             for file in files.documentation_pages():
                 _build_page(file.page, config, files, nav, env, dirty)
 
-            if self.i18n_configs[language]["plugins"]["with-pdf"]:
-                self.i18n_configs[language]["plugins"].run_event('post_build', config=config)
+            if "with-pdf" in self.i18n_configs[language]["plugins"]:
+                self.i18n_configs[language]["plugins"].run_event(
+                    "post_build", config=config
+                )
 
             # Update the search plugin index with language pages
             if search_plugin:

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -118,6 +118,7 @@ class I18n(BasePlugin):
         """
         Enrich configuration with language specific knowledge.
         """
+        if 'skip_i18n' in config: return
         self.default_language = self.config["default_language"]
         # Make a order preserving list of all the configured
         # languages, add the default one first if not listed by the user
@@ -431,7 +432,7 @@ class I18n(BasePlugin):
         We build every language on its own directory.
         """
         # skip language builds requested?
-        if self.config["default_language_only"] is True:
+        if self.config["default_language_only"] is True or 'skip_i18n' in config:
             return
 
         dirty = False
@@ -466,6 +467,9 @@ class I18n(BasePlugin):
 
             for file in files.documentation_pages():
                 _build_page(file.page, config, files, nav, env, dirty)
+
+            if self.i18n_configs[language]["plugins"]["with-pdf"]:
+                self.i18n_configs[language]["plugins"].run_event('post_build', config=config)
 
             # Update the search plugin index with language pages
             if search_plugin:

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -492,11 +492,6 @@ class I18n(BasePlugin):
             for file in files.documentation_pages():
                 _build_page(file.page, config, files, nav, env, dirty)
 
-            if "with-pdf" in self.i18n_configs[language]["plugins"]:
-                self.i18n_configs[language]["plugins"].run_event(
-                    "post_build", config=config
-                )
-
             # Update the search plugin index with language pages
             if search_plugin:
                 if (


### PR DESCRIPTION
Overall PR: https://github.com/mkdocs/mkdocs/pull/2487

To make this plugin compatible with the [mkdocs-with-pdf](https://github.com/orzih/mkdocs-with-pdf) we have to prefix the pdf config output path with the language and call corresponding events on deep copied language config.