### PR TITLE
post_build: support explicitly mkdocs-awesome-pages-plugin nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,6 @@ plugins:
           Topic2: Sujet2
 ```
 
-**NOTE**: this option [is not compatible](https://github.com/ultrabug/mkdocs-static-i18n/issues/65)
-with the `awesome-pages` plugin!
-
 ## Localized content can diverge from the default version
 
 Since version 0.20 of the plugin, localized content can diverge from the
@@ -251,7 +248,7 @@ build.
 This plugin is compatible with the following mkdocs plugins:
 
 - [MkDocs Material](https://github.com/squidfunk/mkdocs-material): the `search` plugin text will be switched automatically to the right language depending on the version you're browsing and the `language selector` will automatically be setup for you (requires mkdocs-material>=7.1.0)
-- [MkDocs Awesome Pages Plugin](https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin): the page ordering is preserved on the language specific versions of your site [but it prevents the 'nav_translations' option to work](https://github.com/ultrabug/mkdocs-static-i18n/issues/65)
+- [MkDocs Awesome Pages Plugin](https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin): the page ordering is preserved on the language specific versions of your site
 
 ## Adding a language selector on your documentation header
 


### PR DESCRIPTION
do not recursively call 'on_nav' to fix issue #65

this makes this plugin and the awesome-pages one 100% compatible
thanks to @phasel74, @scmcca and of course @lukasgeiter