### PR TITLE
improve _fix_search_duplicates performance

### DIFF
--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -335,17 +335,17 @@ class I18n(BasePlugin):
         content is the same as its /language counterpart.
         """
         entries = deepcopy(search_plugin.search_index._entries)
-        for entry in entries:
-            if entry["location"].startswith(f"{language}/"):
-                for s_entry in search_plugin.search_index._entries:
-                    expected_locations = [
-                        f"{language}/{s_entry['location']}",
-                        f"{language}/{s_entry['location'].rstrip('/')}",
-                        f"{language}/{s_entry['location'].replace('/#', '#')}",
-                    ]
-                    if entry["location"] in expected_locations:
-                        if entry["text"] == s_entry["text"]:
-                            search_plugin.search_index._entries.remove(entry)
+        default_lang_entries = filter(lambda x: not x["location"].startswith(tuple(self.config["languages"].keys())), search_plugin.search_index._entries)
+        target_lang_entries = list(filter(lambda x: x["location"].startswith(f"{language}/"), entries))
+        for default_lang_entry in default_lang_entries:
+            expected_locations = [
+                f"{language}/{default_lang_entry['location']}",
+                f"{language}/{default_lang_entry['location'].rstrip('/')}",
+                f"{language}/{default_lang_entry['location'].replace('/#', '#')}",
+            ]
+            duplicated_entries = filter(lambda x: x["location"] in expected_locations and x["text"] == default_lang_entry["text"], target_lang_entries)
+            for duplicated_entry in duplicated_entries:
+                search_plugin.search_index._entries.remove(duplicated_entry)
 
     def on_page_context(self, context, page, config, nav):
         """


### PR DESCRIPTION
Signed-off-by: AngryMane <regulation_dango@yahoo.co.jp>

# Preface
I often use this plugin and build our tech documents. Thank you for the greate plugin!  

# What is changed? 
As #57([feedback] Large site friction) mentioned, there are some performance challenges. This PR modifies the __fix_search_duplicate function. input and output are unchanged, just the way of writing for-loop and other processes is changed.

# How effective is it?
In one sample project(see attached file!), I observed the following effects.
- Before
    -  whole build time : 150 sec
    - _fix_search_duplicates: 35 sec
- After
    -  whole build time : 120 sec
    - _fix_search_duplicates: 8 sec

# Detail
As you can see, _fix_search_duplicates takes 35 sec when building sample project. This is 24% of the total time(150 sec)
[mkdocs-test-sample.zip](https://github.com/ultrabug/mkdocs-static-i18n/files/7654323/mkdocs-test-sample.zip)
.

```
$ ~/work/git/mkdocs-test-sample$ ./cProfileViewer.py 
Sun Dec  5 01:09:17 2021    cProfile_without_patch

         521553167 function calls (499930000 primitive calls) in 150.280 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   1072/1    0.003    0.000  161.509  161.509 {built-in method builtins.exec}
        1    0.000    0.000  161.509  161.509 /home/user/work/git/mkdocs/mkdocs/__main__.py:3(<module>)
        1    0.000    0.000  161.360  161.360 /home/user/.local/lib/python3.8/site-packages/click/core.py:827(__call__)
        1    0.000    0.000  161.360  161.360 /home/user/.local/lib/python3.8/site-packages/click/core.py:716(main)
        1    0.000    0.000  161.360  161.360 /home/user/.local/lib/python3.8/site-packages/click/core.py:1221(invoke)
        2    0.000    0.000  161.360   80.680 /home/user/.local/lib/python3.8/site-packages/click/core.py:1060(invoke)
        2    0.000    0.000  161.360   80.680 /home/user/.local/lib/python3.8/site-packages/click/core.py:572(invoke)
        1    0.000    0.000  161.360  161.360 /home/user/work/git/mkdocs/mkdocs/__main__.py:183(build_command)
        1    0.002    0.002  160.747  160.747 /usr/local/lib/python3.8/dist-packages/mkdocs-1.2.3-py3.8.egg/mkdocs/commands/build.py:241(build)
9320/3114    0.010    0.000  126.906    0.041 /usr/local/lib/python3.8/dist-packages/mkdocs-1.2.3-py3.8.egg/mkdocs/plugins.py:89(run_event)
        1    0.005    0.005  125.371  125.371 /usr/local/lib/python3.8/dist-packages/mkdocs_static_i18n-0.22-py3.8.egg/mkdocs_static_i18n/plugin.py:378(on_post_build)
     1551    0.019    0.000   68.710    0.044 /usr/local/lib/python3.8/dist-packages/mkdocs-1.2.3-py3.8.egg/mkdocs/commands/build.py:189(_build_page)
12047947/2606594    2.535    0.000   61.122    0.000 {method 'join' of 'str' objects}
     1553    0.004    0.000   60.662    0.039 /home/user/.local/lib/python3.8/site-packages/jinja2/environment.py:1076(render)
3207738/65055    4.229    0.000   58.380    0.001 /home/user/.local/lib/python3.8/site-packages/jinja2/runtime.py:260(call)
3184458/41775    3.728    0.000   58.228    0.001 /home/user/.local/lib/python3.8/site-packages/jinja2/runtime.py:597(__call__)
3184458/41775    1.377    0.000   58.164    0.001 /home/user/.local/lib/python3.8/site-packages/jinja2/runtime.py:677(_invoke)
        1   25.903   25.903   35.762   35.762 /usr/local/lib/python3.8/dist-packages/mkdocs_static_i18n-0.22-py3.8.egg/mkdocs_static_i18n/plugin.py:328(_fix_search_duplicates)
```
So I fixed _fix_search_duplicates function. Processing time for _fix_search_duplicates is now 8 seconds.

```
$ ~/work/git/mkdocs-test-sample$ ./cProfileViewer.py 
Sun Dec  5 01:25:55 2021    cProfile_with_patch

         448663674 function calls (427039025 primitive calls) in 121.697 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   1072/1    0.003    0.000  132.982  132.982 {built-in method builtins.exec}
        1    0.000    0.000  132.982  132.982 /home/user/work/git/mkdocs/mkdocs/__main__.py:3(<module>)
        1    0.000    0.000  132.835  132.835 /home/user/.local/lib/python3.8/site-packages/click/core.py:827(__call__)
        1    0.000    0.000  132.835  132.835 /home/user/.local/lib/python3.8/site-packages/click/core.py:716(main)
        1    0.000    0.000  132.835  132.835 /home/user/.local/lib/python3.8/site-packages/click/core.py:1221(invoke)
        2    0.000    0.000  132.834   66.417 /home/user/.local/lib/python3.8/site-packages/click/core.py:1060(invoke)
        2    0.000    0.000  132.834   66.417 /home/user/.local/lib/python3.8/site-packages/click/core.py:572(invoke)
        1    0.000    0.000  132.834  132.834 /home/user/work/git/mkdocs/mkdocs/__main__.py:183(build_command)
        1    0.002    0.002  132.223  132.223 /usr/local/lib/python3.8/dist-packages/mkdocs-1.2.3-py3.8.egg/mkdocs/commands/build.py:241(build)
        ~~~ omitted ~~~
        1    3.175    3.175    8.148    8.148 /usr/local/lib/python3.8/dist-packages/mkdocs_static_i18n-0.22-py3.8.egg/mkdocs_static_i18n/plugin.py:328(_fix_search_duplicates)
```

My current documentation using mkdocs is much larger than this sample project and takes more than 4 hours to build. Therefore, with just this improvement, the build time can be reduced by almost 50 minutes. (This is my personal story, of course).

Thank you! 