### PR TITLE
on_files: do not skip I18nFiles creation on default_language_only

### DIFF
--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -264,10 +264,6 @@ class I18n(BasePlugin):
             )
             main_files.append(main_i18n_file)
 
-            # user requested only the default version to be built
-            if self.config["default_language_only"] is True:
-                continue
-
             for language in self.all_languages:
                 i18n_file = I18nFile(
                     fileobj,
@@ -430,7 +426,7 @@ class I18n(BasePlugin):
 
         We build every language on its own directory.
         """
-        # skip language builds requested?
+        # user requested only the default version to be built
         if self.config["default_language_only"] is True:
             return
 


### PR DESCRIPTION
@Stanzilla reported rightly that when using
default_language_only=true, the build process outputs warning
logs like:

f"A relative path to '{link.url}' is included in the 'nav' "
"configuration, which is not found in the documentation files"

this is due to a premature skip of i18n files population in the
on_files event

closes #83