### PR TITLE
initial implementation of sitemap alternate support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include mkdocs_static_i18n/custom_i18n_sitemap/*

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Supported parameters:
 
 Basic usage:
 
-```
+```yaml
 plugins:
   - i18n:
       default_language: en
@@ -98,7 +98,7 @@ The `mkdocs-static-i18n` provides and will generate an alternate aware `sitemap.
 
 Localization aware sitemap.xml:
 
-```
+```xml
     <url>
          <loc>https://ultrabug.github.io/mkdocs-static-i18n/</loc>
          <lastmod>2022-01-31</lastmod>
@@ -114,7 +114,7 @@ If you do not wish to build a dedicated `<language>/` path for the `default_lang
 
 The following configuration:
 
-```
+```yaml
 plugins:
   - i18n:
       default_language: en
@@ -219,7 +219,7 @@ pages which share the same title.
 This example will translate **any** navigation item title from **Topic1** to
 **Sujet1** on the French version of the documentation:
 
-```
+```yaml
 plugins:
   - i18n:
       default_language: en
@@ -278,7 +278,7 @@ Even better, `mkdocs-static-i18n` will also make it so that changing between lan
 
 If you wish to disable that feature, simply set the `material_alternate` option to `false`:
 
-```
+```yaml
 plugins:
   - i18n:
       default_language: en
@@ -299,7 +299,7 @@ The following explanation was showcased in the demo website up to 0.7 so you can
 
 We need to add a `custom_dir` to our `theme` configuration:
 
-```
+```yaml
 theme:
   name: material
   custom_dir: theme_overrides

--- a/README.md
+++ b/README.md
@@ -92,6 +92,22 @@ site
     └── index.html
 ```
 
+### Alternate aware sitemap.xml
+
+The `mkdocs-static-i18n` provides and will generate an alternate aware `sitemap.xml` for you automatically so that your localized content is made available to search engines!
+
+Localization aware sitemap.xml:
+
+```
+    <url>
+         <loc>https://ultrabug.github.io/mkdocs-static-i18n/</loc>
+         <lastmod>2022-01-31</lastmod>
+         <changefreq>daily</changefreq>
+         <xhtml:link rel="alternate" hreflang="en" href="https://ultrabug.github.io/mkdocs-static-i18n/en/"/>
+         <xhtml:link rel="alternate" hreflang="fr" href="https://ultrabug.github.io/mkdocs-static-i18n/fr/"/>
+    </url>
+```
+
 ### Not building a dedicated version for the default language
 
 If you do not wish to build a dedicated `<language>/` path for the `default_language` version of your documentation, **simply do not list it on the `languages`** list. See issue #5 for more information.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ site
 
 ### Alternate aware sitemap.xml
 
-The `mkdocs-static-i18n` provides and will generate an alternate aware `sitemap.xml` for you automatically so that your localized content is made available to search engines!
+The `mkdocs-static-i18n` plugin since version 0.32 provides a template that will generate automatically an alternate aware `sitemap.xml` so that your localized content is made available to search engines!
 
 Localization aware sitemap.xml:
 

--- a/mkdocs_static_i18n/custom_i18n_sitemap/sitemap.xml
+++ b/mkdocs_static_i18n/custom_i18n_sitemap/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{%- for file in pages -%}
+    {% if not file.page.is_link %}
+    <url>
+         <loc>{% if file.page.canonical_url %}{{ file.page.canonical_url|e }}{% elif file.page.abs_url %}{{ file.page.abs_url|e }}{% else %}{{ config.site_url }}{{ file.url }}{% endif %}</loc>
+         {% if file.page.update_date %}<lastmod>{{file.page.update_date}}</lastmod>{% endif %}
+         <changefreq>daily</changefreq>
+         {% for locale, i18n_file in file.alternates.items() -%}
+         {% if i18n_file %}<xhtml:link rel="alternate" hreflang="{{ locale }}" href="{% if i18n_file.page.canonical_url %}{{ i18n_file.page.canonical_url|e }}{% else %}{{ config.site_url }}{{ i18n_file.url }}{% endif %}"/>{% endif %}
+         {% endfor %}
+    </url>
+    {%- endif -%}
+{% endfor %}
+</urlset>

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -293,6 +293,40 @@ class I18n(BasePlugin):
         # print([{p.src_path: p.url} for p in self.i18n_files["en"].static_pages()])
         # print([{p.src_path: p.url} for p in self.i18n_files["fr"].static_pages()])
 
+        # populate pages alternates
+        # main default version
+        for page in main_files.documentation_pages():
+            for language in self.all_languages:
+                alternate = self.i18n_files[language].get_localized_page_from_url(
+                    page.url, language
+                )
+                if alternate:
+                    page.alternates[language] = alternate
+                else:
+                    log.warning(
+                        f"could not find '{language}' alternate for the default version of page '{page.src_path}'"
+                    )
+        # localized versions
+        # for files in self.i18n_files.values():
+        #     for page in files.documentation_pages():
+        #         url = page.url
+        #         if url.startswith(f"{files.locale}/"):
+        #             url = url.replace(f"{files.locale}/", "", 1) or "."
+        #         for language in self.all_languages:
+        #             alternate = self.i18n_files[language].get_localized_page_from_url(
+        #                 url, language
+        #             )
+        #             if not alternate:
+        #                 page.alternates[
+        #                     language
+        #                 ] = main_files.get_localized_page_from_url(url, "")
+        #             if alternate:
+        #                 page.alternates[language] = alternate
+        #             else:
+        #                 log.warning(
+        #                     f"could not find '{language}' alternate for the '{files.locale}' version of page '{page.src_path}'"
+        #                 )
+
         return main_files
 
     def _fix_config_navigation(self, language, files):

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -9,6 +9,7 @@ from mkdocs.config.config_options import Type
 from mkdocs.plugins import BasePlugin
 from mkdocs.structure.nav import get_navigation
 
+from mkdocs_static_i18n import __file__ as installation_path
 from mkdocs_static_i18n.struct import I18nFile
 
 from .struct import I18nFiles, Locale
@@ -236,6 +237,14 @@ class I18n(BasePlugin):
                     except AttributeError:
                         # partials don't have a module
                         pass
+        # Install a i18n aware version of sitemap.xml if not provided by the user
+        if not Path(
+            Path(config["theme"]._vars.get("custom_dir", ".")) / Path("sitemap.xml")
+        ).exists():
+            custom_i18n_sitemap_dir = Path(
+                Path(installation_path).parent / Path("custom_i18n_sitemap")
+            ).resolve()
+            config["theme"].dirs.insert(0, str(custom_i18n_sitemap_dir))
         return config
 
     def on_files(self, files, config):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,3 +31,18 @@ def test_plugin_single_language_fr():
     )
     result = plugin.on_config(config, force=True)
     assert str(result["theme"]["locale"]) == "fr"
+
+
+def test_plugin_theme_sitemap():
+    plugin = I18n()
+    plugin.load_config({"default_language": "fr", "languages": {"fr": "français"}})
+    config = load_config(
+        "tests/mkdocs_base.yml",
+        theme={"name": "mkdocs"},
+        use_directory_urls=True,
+        docs_dir="../docs/",
+        site_url="http://localhost",
+        extra_javascript=[],
+    )
+    result = plugin.on_config(config, force=True)
+    assert result["theme"].dirs[0].endswith("custom_i18n_sitemap")


### PR DESCRIPTION
given that we provide a sitemap.xml template from theme.custom_dir
this allows to generate alternate links to make the sitemap
support multiple languages

https://developers.google.com/search/docs/advanced/crawling/localized-versions#sitemap

closes #47
closes #54