### PR TITLE
Future-proofing by not accessing private members of `Files`

### DIFF
--- a/mkdocs_static_i18n/folder_structure.py
+++ b/mkdocs_static_i18n/folder_structure.py
@@ -33,10 +33,10 @@ class I18nFolderFiles(Files):
 
         The first I18nFolderFile is sufficient to cover all their possible localized versions.
         """
-        for inside_file in [*self._files]:
+        for inside_file in self:
             if inside_file.dest_path == file.dest_path:
                 return
-        self._files.append(file)
+        super().append(file)
 
     def __contains__(self, path):
         """
@@ -66,7 +66,7 @@ class I18nFolderFiles(Files):
         if language:
             url = f"{language}/{url}"
         url = url.rstrip(".") or "."
-        for file in self._files:
+        for file in self:
             if not file.is_documentation_page():
                 continue
             if file.url == url:

--- a/mkdocs_static_i18n/suffix_structure.py
+++ b/mkdocs_static_i18n/suffix_structure.py
@@ -33,10 +33,10 @@ class I18nFiles(Files):
 
         The first i18nFile is sufficient to cover all their possible localized versions.
         """
-        for inside_file in [*self._files]:
+        for inside_file in self:
             if inside_file.dest_path == file.dest_path:
                 return
-        self._files.append(file)
+        super().append(file)
 
     def __contains__(self, path):
         """
@@ -75,7 +75,7 @@ class I18nFiles(Files):
         if language:
             url = f"{language}/{url}"
         url = url.rstrip(".") or "."
-        for file in self._files:
+        for file in self:
             if not file.is_documentation_page():
                 continue
             if file.url == url:


### PR DESCRIPTION
See https://github.com/mkdocs/mkdocs/pull/2930 commit "[Cache `src_uris`](https://github.com/mkdocs/mkdocs/pull/2930/commits/55449b2e56607971ed8877adfb38efbe81cb92d1)"