### PR TITLE
Add custom link option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Allowed options per language:
 
 - `name` (mandatory): the name that should be displayed in the [mkdocs-material language switcher](#using-mkdocs-material-site-language-selector)
 - `link` (default: `./<language>`): the link path to be used in the [mkdocs-material language switcher](#using-mkdocs-material-site-language-selector)
-- `fixed_link` (default: `None`): if specified, when switching to this language, you will be redirected to this link.
+- `fixed_link` (default: `None`): if specified, when switching to this language, you will be redirected to this link
 - `build` (default: `true`): a boolean used to control the build of a `/<language>` path for the given language
 - `site_name` (default: `mkdocs.yml site_name`): the [`site_name` translation for the given language](#translating-site-name)
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Allowed options per language:
 
 - `name` (mandatory): the name that should be displayed in the [mkdocs-material language switcher](#using-mkdocs-material-site-language-selector)
 - `link` (default: `./<language>`): the link path to be used in the [mkdocs-material language switcher](#using-mkdocs-material-site-language-selector)
+- `fixed_link` (default: `None`): if specified, when switching to this language, you will be redirected to this link.
 - `build` (default: `true`): a boolean used to control the build of a `/<language>` path for the given language
 - `site_name` (default: `mkdocs.yml site_name`): the [`site_name` translation for the given language](#translating-site-name)
 

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -470,7 +470,8 @@ class I18n(BasePlugin):
             for alternate in alternates:
                 if config.get("use_directory_urls") is False:
                     alternate["link"] = alternate["link"].replace("/index.html", "", 1)
-                if fixed_link := alternate["fixed_link"]:
+                fixed_link = alternate["fixed_link"]
+                if fixed_link:
                     alternate["link"] = fixed_link
                 else:
                     if not alternate["link"].endswith("/"):

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -134,24 +134,24 @@ class I18n(BasePlugin):
             {
                 "name": "default",
                 "link": "./",
+                "fixed_link": None,
                 "build": True,
                 "site_name": config["site_name"],
             },
         )
         if self.default_language_options["name"] == "default":
-            default_language_name = (
-                self.config["languages"]
-                .get(self.default_language, {})
-                .get("name", self.default_language)
+            default_language_config = self.config["languages"].get(
+                self.default_language, {}
             )
-            default_language_site_name = (
-                self.config["languages"]
-                .get(self.default_language, {})
-                .get("site_name", config["site_name"])
+            self.default_language_options["name"] = default_language_config.get(
+                "name", self.default_language
             )
-            self.default_language_options["name"] = default_language_name
-            self.default_language_options["site_name"] = default_language_site_name
-
+            self.default_language_options["site_name"] = default_language_config.get(
+                "site_name", config["site_name"]
+            )
+            self.default_language_options["fixed_link"] = default_language_config.get(
+                "fixed_link", None
+            )
         # when the default language is listed on the languages
         # this means that the user wants a /default_language version
         # of his website
@@ -164,6 +164,7 @@ class I18n(BasePlugin):
             self.config["languages"][self.default_language] = {
                 "name": self.default_language_options["name"],
                 "link": "./",
+                "fixed_link": None,
                 "build": build,
                 "site_name": config["site_name"],
             }
@@ -257,6 +258,7 @@ class I18n(BasePlugin):
                             {
                                 "name": f"{self.default_language_options['name']}",
                                 "link": f"{self.default_language_options['link']}{link_suffix}",
+                                "fixed_link": self.default_language_options["fixed_link"],
                                 "lang": self.default_language,
                             }
                         )
@@ -272,6 +274,7 @@ class I18n(BasePlugin):
                                 {
                                     "name": f"{lang_config['name']}",
                                     "link": f"{lang_config['link']}{link_suffix}",
+                                    "fixed_link": lang_config["fixed_link"],
                                     "lang": language,
                                 }
                             )
@@ -465,13 +468,14 @@ class I18n(BasePlugin):
                     break
 
             for alternate in alternates:
-                if alternate["link"].endswith("/"):
-                    separator = ""
-                else:
-                    separator = "/"
                 if config.get("use_directory_urls") is False:
                     alternate["link"] = alternate["link"].replace("/index.html", "", 1)
-                alternate["link"] += f"{separator}{page_url}"
+                if fixed_link := alternate["fixed_link"]:
+                    alternate["link"] = fixed_link
+                else:
+                    if not alternate["link"].endswith("/"):
+                        alternate["link"] += "/"
+                    alternate["link"] += page_url
             config["extra"]["alternate"] = alternates
 
         # set the localized site_name if any

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -258,7 +258,9 @@ class I18n(BasePlugin):
                             {
                                 "name": f"{self.default_language_options['name']}",
                                 "link": f"{self.default_language_options['link']}{link_suffix}",
-                                "fixed_link": self.default_language_options["fixed_link"],
+                                "fixed_link": self.default_language_options[
+                                    "fixed_link"
+                                ],
                                 "lang": self.default_language,
                             }
                         )

--- a/mkdocs_static_i18n/structure.py
+++ b/mkdocs_static_i18n/structure.py
@@ -47,10 +47,11 @@ class Locale(Type):
                 name: Français
                 build: true
         """
-        allowed_keys = set(["name", "link", "build", "site_name"])
+        allowed_keys = set(["name", "link", "build", "site_name", "fixed_link"])
         lang_config = {
             "build": True,
             "link": f"./{lang_key}/" if lang_key != "default" else "./",
+            "fixed_link": None,
             "name": lang_key,
             "site_name": None,
         }

--- a/requirements-qa.txt
+++ b/requirements-qa.txt
@@ -1,4 +1,4 @@
 black==22.6.0
-flake8==4.0.1
+flake8==5.0.4
 isort==5.10.1
 pytest==7.1.2

--- a/tests/mkdocs_i18n_fixed_link.yml
+++ b/tests/mkdocs_i18n_fixed_link.yml
@@ -1,0 +1,13 @@
+site_name: MkDocs static i18n plugin tests with fixed link
+site_url: http://localhost
+
+plugins:
+  - i18n:
+      default_language: en
+      languages:
+        en:
+          name: English
+          fixed_link: /en
+        fr:
+          name: Français
+          fixed_link: /fr

--- a/tests/test_language_selector.py
+++ b/tests/test_language_selector.py
@@ -1,15 +1,5 @@
 from mkdocs.config.base import load_config
 
-ALTERNATE_NO_USE_DIRECTORY_URLS = [
-    {"name": "english", "link": "./index.html", "lang": "en"},
-    {"name": "français", "link": "./fr/index.html", "lang": "fr"},
-]
-
-ALTERNATE_USE_DIRECTORY_URLS = [
-    {"name": "english", "link": "./", "lang": "en"},
-    {"name": "français", "link": "./fr/", "lang": "fr"},
-]
-
 
 def test_plugin_language_selector_use_directory_urls():
     mkdocs_config = load_config(
@@ -28,7 +18,10 @@ def test_plugin_language_selector_use_directory_urls():
     )
     i18n_plugin = mkdocs_config["plugins"]["i18n"]
     result = i18n_plugin.on_config(mkdocs_config, force=True)
-    assert result["extra"]["alternate"] == ALTERNATE_USE_DIRECTORY_URLS
+    assert result["extra"]["alternate"] == [
+        {"name": "english", "link": "./", "fixed_link": None, "lang": "en"},
+        {"name": "français", "link": "./fr/", "fixed_link": None, "lang": "fr"},
+    ]
 
 
 def test_plugin_language_selector_no_use_directory_urls():
@@ -48,7 +41,10 @@ def test_plugin_language_selector_no_use_directory_urls():
     )
     i18n_plugin = mkdocs_config["plugins"]["i18n"]
     result = i18n_plugin.on_config(mkdocs_config, force=True)
-    assert result["extra"]["alternate"] == ALTERNATE_NO_USE_DIRECTORY_URLS
+    assert result["extra"]["alternate"] == [
+        {"name": "english", "link": "./index.html", "fixed_link": None, "lang": "en"},
+        {"name": "français", "link": "./fr/index.html", "fixed_link": None, "lang": "fr"},
+    ]
 
 
 def test_plugin_language_selector_single_default_language():
@@ -88,7 +84,32 @@ def test_plugin_language_selector_use_directory_urls_default():
     i18n_plugin = mkdocs_config["plugins"]["i18n"]
     result = i18n_plugin.on_config(mkdocs_config, force=True)
     assert result["extra"]["alternate"] == [
-        {"name": "default_english", "link": "./", "lang": "en"},
-        {"name": "français", "link": "./fr/", "lang": "fr"},
-        {"name": "english", "link": "./en/", "lang": "en"},
+        {"name": "default_english", "link": "./", "fixed_link": None, "lang": "en"},
+        {"name": "français", "link": "./fr/", "fixed_link": None, "lang": "fr"},
+        {"name": "english", "link": "./en/", "fixed_link": None, "lang": "en"},
+    ]
+
+
+def test_plugin_language_selector_fixed_link():
+    mkdocs_config = load_config(
+        "tests/mkdocs_base.yml",
+        theme={"name": "mkdocs"},
+        docs_dir="docs_suffix_structure/",
+        site_url="http://localhost",
+        extra_javascript=[],
+        plugins={
+            "i18n": {
+                "default_language": "en",
+                "languages": {
+                    "fr": {"name": "français", "fixed_link": "/fr"},
+                    "en": {"name": "english", "fixed_link": "/en"},
+                },
+            }
+        },
+    )
+    i18n_plugin = mkdocs_config["plugins"]["i18n"]
+    result = i18n_plugin.on_config(mkdocs_config, force=True)
+    assert result["extra"]["alternate"] == [
+        {"name": "english", "link": "./", "fixed_link": "/en", "lang": "en"},
+        {"name": "français", "link": "./fr/", "fixed_link": "/fr", "lang": "fr"},
     ]

--- a/tests/test_language_selector.py
+++ b/tests/test_language_selector.py
@@ -43,7 +43,12 @@ def test_plugin_language_selector_no_use_directory_urls():
     result = i18n_plugin.on_config(mkdocs_config, force=True)
     assert result["extra"]["alternate"] == [
         {"name": "english", "link": "./index.html", "fixed_link": None, "lang": "en"},
-        {"name": "français", "link": "./fr/index.html", "fixed_link": None, "lang": "fr"},
+        {
+            "name": "français",
+            "link": "./fr/index.html",
+            "fixed_link": None,
+            "lang": "fr",
+        },
     ]
 
 

--- a/tests/test_language_selector.py
+++ b/tests/test_language_selector.py
@@ -97,7 +97,7 @@ def test_plugin_language_selector_use_directory_urls_default():
 
 def test_plugin_language_selector_fixed_link():
     mkdocs_config = load_config(
-        "tests/mkdocs_base.yml",
+        "tests/mkdocs_i18n_fixed_link.yml",
         theme={"name": "mkdocs"},
         docs_dir="docs_suffix_structure/",
         site_url="http://localhost",

--- a/tests/test_languages_option.py
+++ b/tests/test_languages_option.py
@@ -22,12 +22,14 @@ def test_plugin_languages_backward_compat_1():
         "en": {
             "name": "english",
             "link": "./en/",
+            "fixed_link": None,
             "build": True,
             "site_name": "MkDocs static i18n plugin tests",
         },
         "fr": {
             "name": "français",
             "link": "./fr/",
+            "fixed_link": None,
             "build": True,
             "site_name": "MkDocs static i18n plugin tests",
         },
@@ -50,6 +52,7 @@ def test_plugin_languages_backward_compat_2():
         "en": {
             "name": "english",
             "link": "./en/",
+            "fixed_link": None,
             "build": True,
             "site_name": "MkDocs static i18n plugin tests",
         },
@@ -72,12 +75,14 @@ def test_plugin_languages_backward_compat_3():
         "en": {
             "name": "en",
             "link": "./",
+            "fixed_link": None,
             "build": False,
             "site_name": "MkDocs static i18n plugin tests",
         },
         "fr": {
             "name": "français",
             "link": "./fr/",
+            "fixed_link": None,
             "build": True,
             "site_name": "MkDocs static i18n plugin tests",
         },
@@ -105,12 +110,14 @@ def test_plugin_languages_backward_compat_4():
         "en": {
             "name": "english_default",
             "link": "./",
+            "fixed_link": None,
             "build": False,
             "site_name": "MkDocs static i18n plugin tests",
         },
         "fr": {
             "name": "français",
             "link": "./fr/",
+            "fixed_link": None,
             "build": True,
             "site_name": "MkDocs static i18n plugin tests",
         },
@@ -146,12 +153,14 @@ def test_plugin_languages_backward_compat_5():
         "en": {
             "name": "english",
             "link": "./en/",
+            "fixed_link": None,
             "build": True,
             "site_name": "English site name",
         },
         "fr": {
             "name": "français",
             "link": "./fr/",
+            "fixed_link": None,
             "build": True,
             "site_name": "MkDocs static i18n plugin tests",
         },
@@ -187,12 +196,14 @@ def test_plugin_languages_backward_compat_6():
         "en": {
             "name": "english",
             "link": "./en/",
+            "fixed_link": None,
             "build": False,
             "site_name": "MkDocs static i18n plugin tests",
         },
         "fr": {
             "name": "français",
             "link": "/fr",
+            "fixed_link": None,
             "build": True,
             "site_name": "MkDocs static i18n plugin tests",
         },
@@ -220,12 +231,14 @@ def test_plugin_languages_backward_compat_7():
         "en": {
             "name": "english",
             "link": "./en/",
+            "fixed_link": None,
             "build": True,
             "site_name": "MkDocs static i18n plugin tests",
         },
         "fr": {
             "name": "français",
             "link": "./fr/",
+            "fixed_link": None,
             "build": True,
             "site_name": "MkDocs static i18n plugin tests",
         },
@@ -257,12 +270,14 @@ def test_plugin_languages_backward_compat_8():
         "en": {
             "name": "english",
             "link": "./en/",
+            "fixed_link": None,
             "build": True,
             "site_name": "MkDocs static i18n plugin tests",
         },
         "fr": {
             "name": "français",
             "link": "./fr/",
+            "fixed_link": None,
             "build": True,
             "site_name": "MkDocs static i18n plugin tests",
         },
@@ -294,12 +309,14 @@ def test_plugin_languages_backward_compat_9():
         "en": {
             "name": "english",
             "link": "./en/",
+            "fixed_link": None,
             "build": False,
             "site_name": "MkDocs static i18n plugin tests",
         },
         "fr": {
             "name": "français",
             "link": "./fr/",
+            "fixed_link": None,
             "build": True,
             "site_name": "MkDocs static i18n plugin tests",
         },
@@ -330,12 +347,14 @@ def test_plugin_languages_backward_compat_10():
         "en": {
             "name": "english_default",
             "link": "./",
+            "fixed_link": None,
             "build": False,
             "site_name": "MkDocs static i18n plugin tests",
         },
         "fr": {
             "name": "français",
             "link": "./fr/",
+            "fixed_link": None,
             "build": True,
             "site_name": "MkDocs static i18n plugin tests",
         },
@@ -366,12 +385,14 @@ def test_plugin_languages_backward_compat_11():
         "en": {
             "name": "en",
             "link": "./",
+            "fixed_link": None,
             "build": False,
             "site_name": "MkDocs static i18n plugin tests",
         },
         "fr": {
             "name": "français",
             "link": "./fr/",
+            "fixed_link": None,
             "build": True,
             "site_name": "MkDocs static i18n plugin tests",
         },
@@ -401,6 +422,7 @@ def test_plugin_languages_backward_compat_12():
         "fr": {
             "name": "french_default",
             "link": "./",
+            "fixed_link": None,
             "build": True,
             "site_name": "MkDocs static i18n plugin tests",
         },
@@ -440,12 +462,14 @@ def test_plugin_languages_backward_compat_13():
         "en": {
             "name": "english",
             "link": "./en/",
+            "fixed_link": None,
             "build": True,
             "site_name": "English site name",
         },
         "fr": {
             "name": "français",
             "link": "./fr/",
+            "fixed_link": None,
             "build": True,
             "site_name": "Site en Français",
         },


### PR DESCRIPTION
Hi, I'm @dariocurr, a developer at [BuildNN](https://github.com/buildnn)

Firstly, thank you for your useful plugin.

I made this pull request because we need to specify a custom link when switching languages instead of transforming `/a/page/` to `/b/page/`, since not all languages shares the same pages in our cases. 
With this edit you are able to specify a custom link such as `/en` (not `/en/`), and you'll be redirected directly to that link

**The discriminant is whether the link contains a leading `/` or not**

My pull request is missing tests on this new feature, but before implementing them I wanted to ask if you think this is a good new feature


Note: I fixed a typo in your tox.ini