### PR TITLE
Minify plugin no longer accepts positional arguments

### DIFF
--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -562,7 +562,7 @@ class I18n(BasePlugin):
 
             # Support mkdocs-minify-plugin
             if minify_plugin:
-                minify_plugin.on_pre_build(config)
+                minify_plugin.on_pre_build(config=config)
 
             # Include theme specific files
             files.add_files_from_theme(env, config)


### PR DESCRIPTION
This will still work for older versions, as the argument has always been `config`. In https://github.com/byrnereese/mkdocs-minify-plugin/commit/bdfe0fbe680db26d2d1590d236c5f3162afbbeb9 it was changed to be non-positional.

Fixes this error:

```
File "/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/mkdocs_static_i18n/plugin.py", line 556, in on_post_build
    minify_plugin.on_pre_build(config)
TypeError: MinifyPlugin.on_pre_build() takes 1 positional argument but 2 were given
```