### PR TITLE
feat: make compatible with mkdocs-jupyter

### DIFF
--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -7,6 +7,7 @@ from mkdocs import __version__ as mkdocs_version
 from mkdocs.commands.build import _build_page, _populate_page
 from mkdocs.config.config_options import Choice, Type
 from mkdocs.plugins import BasePlugin
+from mkdocs.utils import markdown_extensions
 
 import mkdocs_static_i18n.folder_structure as folder_structure
 import mkdocs_static_i18n.suffix_structure as suffix_structure
@@ -187,6 +188,10 @@ class I18n(BasePlugin):
             i18n_index = list(config["plugins"].keys()).index("i18n")
         except ValueError:
             i18n_index = -1
+        # TODO: Make sure mkdocs-jupyter is always called before us
+        # Allow ipynb and py format as documentation_page
+        if "mkdocs-jupyter" in config["plugins"]:
+            markdown_extensions.extend([".ipynb", ".py"])
         # Make sure with-pdf is controlled by us, see #110
         # We will only control it for the main language, localized PDF are
         # generated on the 'on_post_build' method


### PR DESCRIPTION
I opened issue #135 a few months ago and recently tried to make it compatible. (sorry for late reply)

The problem was that mkdocs doesn't read ".ipynb" and ".py" as document pages, so I added those extensions if mkdocs-jupyter is in the plugins list.

The code has been tested on this [site](https://docs2.thanosql.ai/tutorials/algorithm_list/) (All Jupyter files are listed in the Tutorials index below.)

One thing left is that mkdocs-jupyter should run before mkdocs-static-i18n. I haven't figured it out yet.

You can reproduct and test with this [repo](https://github.com/yeemh/docs_test/).