### PR TITLE
fix(plugin.on_env): add support for on_env altering hooks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs>=1.2.1
+mkdocs>=1.4.2
 mkdocs-material==8.5.10

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     platforms="any",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["mkdocs>=1.2.3"],
+    install_requires=["mkdocs>=1.4.2"],
     entry_points={"mkdocs.plugins": ["i18n = mkdocs_static_i18n.plugin:I18n"]},
     python_requires=">=3.7",
     classifiers=[

--- a/tests/hooks_jinja_on_env.py
+++ b/tests/hooks_jinja_on_env.py
@@ -1,0 +1,19 @@
+def value_in_frontmatter(key, metadata):
+    """Check if a key exists in the frontmatter.
+
+    Args:
+        key (any): the key to check
+        metadata (any): the frontmatter
+
+    Returns:
+        bool: true if exists
+    """
+    if key in metadata:
+        return metadata[key]
+    else:
+        return None
+
+
+def on_env(env, config, files, **kwargs):
+    env.filters["value_in_frontmatter"] = value_in_frontmatter
+    return env

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -19,3 +19,23 @@ def test_hooks_working():
         hooks=["hooks.py"],
     )
     build(mkdocs_config)
+
+
+def test_hooks_env_modified():
+    mkdocs_config = load_config(
+        "tests/mkdocs_base.yml",
+        theme={"name": "mkdocs", "custom_dir": "theme_overrides"},
+        use_directory_urls=True,
+        docs_dir="docs_suffix_structure/",
+        site_url="http://localhost",
+        extra_javascript=[],
+        plugins={
+            "i18n": {
+                "default_language": "en",
+                "languages": {"fr": "français", "en": "english"},
+            },
+        },
+        hooks=["hooks_jinja_on_env.py"],
+        site_dir="/tmp/xoxo/",
+    )
+    build(mkdocs_config)

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,4 +1,4 @@
-from copy import deepcopy
+from copy import copy
 from pathlib import Path
 
 from mkdocs.commands.build import build
@@ -46,6 +46,8 @@ def test_plugin_static_nav(config_plugin_static_nav):
     files = i18n_plugin.on_files(files, config)
     nav = get_navigation(files, config)
     nav = i18n_plugin.on_nav(nav, config, files)
+    env = config.theme.get_env()
+    env = i18n_plugin.on_env(env, config, files)
     i18n_plugin.on_post_build(config)
     #
     assert i18n_plugin.i18n_configs["en"]["nav"] == EN_STATIC_NAV
@@ -61,14 +63,16 @@ def test_plugin_translated_nav(config_plugin_translated_nav):
     files = i18n_plugin.on_files(files, config)
     nav = get_navigation(files, config)
     nav = i18n_plugin.on_nav(nav, config, files)
+    env = config.theme.get_env()
+    env = i18n_plugin.on_env(env, config, files)
     i18n_plugin.on_post_build(config)
     #
-    fr_config = deepcopy(i18n_plugin.i18n_configs["fr"])
+    fr_config = copy(i18n_plugin.i18n_configs["fr"])
     fr_config["nav"] = FR_TRANSLATED_NAV
     fr_nav = get_navigation(i18n_plugin.i18n_files["fr"], fr_config)
     assert i18n_plugin.i18n_navs["fr"].__repr__() == fr_nav.__repr__()
     #
-    en_config = deepcopy(i18n_plugin.i18n_configs["en"])
+    en_config = copy(i18n_plugin.i18n_configs["en"])
     en_config["nav"] = EN_TRANSLATED_NAV
     en_nav = get_navigation(i18n_plugin.i18n_files["en"], en_config)
     assert i18n_plugin.i18n_navs["en"].__repr__() == en_nav.__repr__()

--- a/tests/theme_overrides/content.html
+++ b/tests/theme_overrides/content.html
@@ -1,0 +1,3 @@
+Testing on_env hooks
+
+{% set test = "comments" | value_in_frontmatter(page.meta) %}


### PR DESCRIPTION
as per issue 178 hooks can alter the jinja2 environment which should be preserved during language builds

closes #178 