### PR TITLE
Allow all standard hreflang language codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.egg-info/
+build/
 dist/
 site/
 .tox/

--- a/mkdocs_static_i18n/structure.py
+++ b/mkdocs_static_i18n/structure.py
@@ -4,7 +4,7 @@ from re import compile
 from mkdocs.config.base import ValidationError
 from mkdocs.config.config_options import Type
 
-RE_LOCALE = compile(r"(^[a-z]{2}_[A-Z]{2}$)|(^[a-z]{2}$)")
+RE_LOCALE = compile(r"(^[a-z]{2}(-[A-Za-z]{4})?(-[A-Z]{2})?$)|(^[a-z]{2}_[A-Z]{2}$)")
 
 log = logging.getLogger("mkdocs.plugins." + __name__)
 


### PR DESCRIPTION
In the `hreflang` tag, languages (ISO 639-1) and countries (ISO 3166-1) should be separated by a hyphen, not an underscore, and you should additionally be able to specify a four-letter language script (ISO 15924). This PR changes the regex to allow you to use any of the following:

- language, ex: `en`
- language-country, ex: `en-US`
- language-script, ex: `zh-Hant`
- language-script-country, ex: `zh-Hant-US`

https://developers.google.com/search/docs/specialty/international/localized-versions#language-codes
https://en.wikipedia.org/wiki/Hreflang

For backwards compatibility this does not remove the ability to use 5 character codes with an underscore like `en_US` even though that is non-standard.

This fixes #193 for me.