### PR TITLE
fix search plugin handling

### DIFF
--- a/mkdocs_static_i18n/utils.py
+++ b/mkdocs_static_i18n/utils.py
@@ -1,0 +1,28 @@
+"""Utility functions that aren't limited to any scenario."""
+from typing import Dict, Optional, TypeVar
+
+from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.plugins import BasePlugin
+
+Plugin = TypeVar("Plugin", bound=BasePlugin)
+"""Plugin Instance Type"""
+
+
+def get_plugin(name: str, config: MkDocsConfig) -> Optional[Plugin]:
+    """Returns a plugin instance"""
+
+    plugins: Dict[str, BasePlugin] = config["plugins"]
+    instance: Plugin = plugins.get(name)
+
+    if instance:
+        return instance
+
+    scoped_name: str = f"/{name}"
+
+    # If the plugin was not found using the name
+    # then look for a theme-namespaced plugin.
+    for n, p in plugins.items():
+        if n.endswith(scoped_name):
+            return p
+
+    return None


### PR DESCRIPTION
Fixes #202 
Fixes #182 
Closes #148 

Hello again 👋,

I've introduced a new file with a function to get a plugin instance no matter if it's theme based or not. However, the algorithm is primitive it doesn't lookup exactly the name of the current theme, because I'm not sure if I can just use `config["theme"]["name"]` 🤔To be honest I like the "wider search scope" of the primitive approach more.

This function might be used with every plugin, but I doubt that any theme will introduce their own `minify` version etc., therefore I didn't refactor any plugin retrieval apart of the `search`.

The new material's theme `search` plugin also breaks the API, so I'm handling both the old `entries` and new `_entries` SearchIndex attributes. I added a fail-safe try/except too, in case some other theme creates their own search plugin with yet another API divergence😅 

I run the tests in the repository, all passed, but I think all tests use the default theme. However, I've been using the initial fix in the Gothic Modding Community's docs for the past month, and no serious issue stuck out. Unfortunately, our alternative languages aren't supported by `lunr.js`, and with the current fix I get a warning 😞. The `lang` attribute is of the same type in the material plugin and default plugin, so everything should be fine 👌