### PR TITLE
add support for --dirty and --dirtyreload

### DIFF
--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -28,6 +28,20 @@ class I18n(ExtendedPlugin):
     """
 
     @plugins.event_priority(-100)
+    def on_startup(self, command: str, dirty: bool):
+        """
+        Store dirty flag to propagate it to language builds.
+        """
+        self.dirty = dirty
+        self.building = False
+        self.current_language = None
+        self.extra_alternate = {}
+        self.i18n_files_per_language = {}
+        self.original_configs = {}
+        self.original_theme_configs = {}
+        self.search_entries = []
+
+    @plugins.event_priority(-100)
     def on_config(self, config: MkDocsConfig):
         """
         Enrich configuration with language specific knowledge.
@@ -185,7 +199,7 @@ class I18n(ExtendedPlugin):
             self.current_language = locale
             log.info(f"Building '{locale}' documentation to directory: {config.site_dir}")
             # TODO: reconfigure config here? skip on_config?
-            build(config)
+            build(config, dirty=self.dirty)
 
             # manually trigger with-pdf for this locale, see #110
             if with_pdf_plugin:
@@ -207,3 +221,5 @@ class I18n(ExtendedPlugin):
         except UnboundLocalError:
             # tests dont setup a duplicatefilter
             pass
+
+        self.building = False

--- a/mkdocs_static_i18n/reconfigure.py
+++ b/mkdocs_static_i18n/reconfigure.py
@@ -87,6 +87,7 @@ class ExtendedPlugin(BasePlugin[I18nPluginConfig]):
         self.original_configs = {}
         self.original_theme_configs = {}
         self.search_entries = []
+        self.dirty = False
 
     @property
     def all_languages(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ def make_config():
             use_directory_urls=use_directory_urls,
             plugins=plugins,
         )
+        config.plugins.run_event("startup", config, dirty=False)
         config = config.plugins.run_event("config", config)
         files = get_files(config)
         files = config.plugins.run_event("files", files, config=config)

--- a/tests/test_language_selector.py
+++ b/tests/test_language_selector.py
@@ -18,6 +18,7 @@ def test_plugin_language_selector_use_directory_urls():
         },
     )
     i18n_plugin = mkdocs_config["plugins"]["i18n"]
+    i18n_plugin.on_startup(command="", dirty=False)
     result = i18n_plugin.on_config(mkdocs_config)
     assert result["extra"]["alternate"] == [
         {"name": "english", "link": "/", "lang": "en"},
@@ -41,6 +42,7 @@ def test_plugin_language_selector_no_use_directory_urls():
         },
     )
     i18n_plugin = mkdocs_config["plugins"]["i18n"]
+    i18n_plugin.on_startup(command="", dirty=False)
     result = i18n_plugin.on_config(mkdocs_config)
     assert result["extra"]["alternate"] == [
         {"name": "english", "link": "/index.html", "lang": "en"},
@@ -74,6 +76,7 @@ def test_plugin_language_selector_fixed_alternate():
         },
     )
     i18n_plugin = mkdocs_config["plugins"]["i18n"]
+    i18n_plugin.on_startup(command="", dirty=False)
     result = i18n_plugin.on_config(mkdocs_config)
     assert result["extra"]["alternate"] == [
         {"name": "english", "link": "/default", "lang": "en"},
@@ -94,6 +97,7 @@ def test_plugin_language_selector_single_default_language():
         },
     )
     i18n_plugin = mkdocs_config["plugins"]["i18n"]
+    i18n_plugin.on_startup(command="", dirty=False)
     result = i18n_plugin.on_config(mkdocs_config)
     assert result["extra"] == {}
 
@@ -118,6 +122,7 @@ def test_plugin_language_selector_fixed_link():
         },
     )
     i18n_plugin = mkdocs_config["plugins"]["i18n"]
+    i18n_plugin.on_startup(command="", dirty=False)
     result = i18n_plugin.on_config(mkdocs_config)
     assert result["extra"]["alternate"] == [
         {"name": "english", "link": "/en", "lang": "en"},
@@ -156,6 +161,7 @@ def test_plugin_language_selector_fixed_link_with_static_alternate():
         },
     )
     i18n_plugin = mkdocs_config["plugins"]["i18n"]
+    i18n_plugin.on_startup(command="", dirty=False)
     result = i18n_plugin.on_config(mkdocs_config)
     assert result["extra"]["alternate"] == [
         {"name": "english", "link": "/", "lang": "en"},

--- a/tests/test_languages_option.py
+++ b/tests/test_languages_option.py
@@ -67,6 +67,7 @@ def test_plugin_languages_dual_lang():
         },
     )
     i18n_plugin = mkdocs_config["plugins"]["i18n"]
+    i18n_plugin.on_startup(command="", dirty=False)
     i18n_plugin.on_config(mkdocs_config)
     assert i18n_plugin.config["languages"] == [
         {
@@ -125,6 +126,7 @@ def test_plugin_languages_one_lang():
         },
     )
     i18n_plugin = mkdocs_config["plugins"]["i18n"]
+    i18n_plugin.on_startup(command="", dirty=False)
     i18n_plugin.on_config(mkdocs_config)
     assert i18n_plugin.config["languages"] == [
         {

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -23,6 +23,7 @@ def test_search_entries():
                 },
             },
         )
+        mkdocs_config["plugins"]["i18n"].on_startup(command="", dirty=False)
         if theme == "material":
             mkdocs_config["plugins"]["material/search"].on_startup(command=None, dirty=False)
         build(mkdocs_config)
@@ -54,6 +55,7 @@ def test_search_entries_no_directory_urls():
             },
         },
     )
+    mkdocs_config["plugins"]["i18n"].on_startup(command="", dirty=False)
     build(mkdocs_config)
     search_plugin = mkdocs_config["plugins"]["search"]
     assert len(search_plugin.search_index._entries) == 34
@@ -80,6 +82,7 @@ def test_search_entries_no_reconfigure():
             },
         },
     )
+    mkdocs_config["plugins"]["i18n"].on_startup(command="", dirty=False)
     build(mkdocs_config)
     search_plugin = mkdocs_config["plugins"]["search"]
     assert len(search_plugin.search_index._entries) == 36
@@ -105,6 +108,7 @@ def test_search_add_lang():
             },
         },
     )
+    mkdocs_config["plugins"]["i18n"].on_startup(command="", dirty=False)
     build(mkdocs_config)
     search_plugin = mkdocs_config["plugins"]["search"]
     assert search_plugin.config["lang"] == ["en", "fr"]
@@ -133,6 +137,7 @@ def test_search_add_missing_lang():
             },
         },
     )
+    mkdocs_config["plugins"]["i18n"].on_startup(command="", dirty=False)
     build(mkdocs_config)
     search_plugin = mkdocs_config["plugins"]["search"]
     assert search_plugin.config["lang"] == ["en", "fr"]
@@ -161,6 +166,7 @@ def test_search_no_add_lang():
             },
         },
     )
+    mkdocs_config["plugins"]["i18n"].on_startup(command="", dirty=False)
     build(mkdocs_config)
     search_plugin = mkdocs_config["plugins"]["search"]
     assert search_plugin.config["lang"] == ["en"]

--- a/tests/test_structure_suffix.py
+++ b/tests/test_structure_suffix.py
@@ -129,6 +129,7 @@ def test_plugin_use_directory_urls():
             },
         },
     )
+    mkdocs_config["plugins"]["i18n"].on_startup(command="", dirty=False)
     build(mkdocs_config)
     site_dir = mkdocs_config["site_dir"]
     generate_site = [f.relative_to(site_dir) for f in Path(site_dir).glob("**/*.html")]
@@ -161,6 +162,7 @@ def test_plugin_use_directory_urls_static_nav():
             }
         ],
     )
+    mkdocs_config["plugins"]["i18n"].on_startup(command="", dirty=False)
     build(mkdocs_config)
     site_dir = mkdocs_config["site_dir"]
     generate_site = [f.relative_to(site_dir) for f in Path(site_dir).glob("**/*.html")]
@@ -188,6 +190,7 @@ def test_plugin_no_use_directory_urls():
             },
         },
     )
+    mkdocs_config["plugins"]["i18n"].on_startup(command="", dirty=False)
     build(mkdocs_config)
     site_dir = mkdocs_config["site_dir"]
     generate_site = [f.relative_to(site_dir) for f in Path(site_dir).glob("**/*.html")]
@@ -239,6 +242,7 @@ def test_plugin_use_directory_urls_default_language_only():
             },
         },
     )
+    mkdocs_config["plugins"]["i18n"].on_startup(command="", dirty=False)
     build(mkdocs_config)
     site_dir = mkdocs_config["site_dir"]
     generate_site = [f.relative_to(site_dir) for f in Path(site_dir).glob("**/*.html")]
@@ -266,6 +270,7 @@ def test_plugin_no_use_directory_urls_default_language_only():
             },
         },
     )
+    mkdocs_config["plugins"]["i18n"].on_startup(command="", dirty=False)
     build(mkdocs_config)
     site_dir = mkdocs_config["site_dir"]
     generate_site = [f.relative_to(site_dir) for f in Path(site_dir).glob("**/*.html")]


### PR DESCRIPTION
This PR is rework of the following PR. 
https://github.com/ultrabug/mkdocs-static-i18n/pull/248
---

Hi! I issued a PR once a long time ago.  Long time no see.🙂

# description
I found mkdocs supports incremental builds (--dirty and --dirtyreload options), but this plugin does not. 
This PR changes to support them.

# motivation 
If there are many documents, not supporting --dirty and --dirtyreload will cause extra time to build.
(For instance, my documents have been getting larger and larger, eventually taking as long as two minutes to hot reload!)
This PR allows hot reloads to be performed in a fraction of the time.

# remarks
Frankly, I think dirty flag should be passed from mkdocs. However, since it is currently not possible to obtain the flag from mkdocs, I implemented this by referencing sys.argv.