### PR TITLE
fix(assets): Handle more assets

### DIFF
--- a/mkdocs_static_i18n/reconfigure.py
+++ b/mkdocs_static_i18n/reconfigure.py
@@ -611,8 +611,10 @@ class ExtendedPlugin(BasePlugin[I18nPluginConfig]):
                             log.debug(f"Use localized asset {i18n_file.locale} {i18n_file}")
 
             # theme (and overrides) files
-            elif self.is_default_language_build:
+            elif not file.is_documentation_page():
                 i18n_files.append(file)
+            else:
+                log.warning(f"Unhandled file case - {file.src_uri}")
 
         # populate the resulting Files and keep track of all the alternates
         # that will be used by the sitemap.xml template


### PR DESCRIPTION
Some assets (like images) might stay the same across different language builds, as in no localized version is available.
Currently only the default language adds the files to the internal `files` list and built alternates show a warning that a file isn't found in the documentation files.

This PR tries to fix just that by always including any non `.md` file to the build, so that would include `.png` `.jpg` `.js` etc. files. 
As far as I know, the files aren't being duplicated in the alternate builds, just that the path to them is properly resolved.

It partially helps with #251 

EDIT:
Actually, unrelated to #252