### PR TITLE
Fix duplicate log messages

### DIFF
--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -13,7 +13,7 @@ from mkdocs.structure.pages import Page
 
 from mkdocs_static_i18n import folder
 from mkdocs_static_i18n.reconfigure import ExtendedPlugin
-from mkdocs_static_i18n.utils import i18nLoggingFilter
+from mkdocs_static_i18n.utils import I18nLoggingFilter
 
 log = get_plugin_logger(__name__)
 
@@ -164,7 +164,7 @@ class I18n(ExtendedPlugin):
 
         # Block time logging for internal builds and filter reduntant MkDocs log
         build_logger = logging.getLogger("mkdocs.commands.build")
-        i18n_filter = i18nLoggingFilter()
+        i18n_filter = I18nLoggingFilter()
         i18n_filter.filtered_prefixes.add("Documentation built in")
         i18n_filter.filtered_prefixes.add("Building documentation to directory")
         build_logger.addFilter(i18n_filter)

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -37,6 +37,10 @@ class I18n(ExtendedPlugin):
         # first execution, setup defaults
         if self.current_language is None:
             self.current_language = self.default_language
+            log.info(
+                f"Building '{self.current_language}' documentation to directory: {config.site_dir}"
+            )
+
         # reconfigure the mkdocs config
         return self.reconfigure_mkdocs_config(config)
 
@@ -158,9 +162,11 @@ class I18n(ExtendedPlugin):
 
         self.building = True
 
-        # Block time logging for internal builds
+        # Block time logging for internal builds and filter reduntant MkDocs log
         build_logger = logging.getLogger("mkdocs.commands.build")
         i18n_filter = i18nLoggingFilter()
+        i18n_filter.filtered_prefixes.add("Documentation built in")
+        i18n_filter.filtered_prefixes.add("Building documentation to directory")
         build_logger.addFilter(i18n_filter)
 
         # manually trigger with-pdf, see #110

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -37,9 +37,13 @@ class I18n(ExtendedPlugin):
         # first execution, setup defaults
         if self.current_language is None:
             self.current_language = self.default_language
-            log.info(
-                f"Building '{self.current_language}' documentation to directory: {config.site_dir}"
-            )
+
+        path_suffix = self.current_language if not self.is_default_language_build else ""
+
+        log.info(
+            f"Building '{self.current_language}' documentation to directory: "
+            f"{PurePath(config.site_dir) / path_suffix}"
+        )
 
         # reconfigure the mkdocs config
         return self.reconfigure_mkdocs_config(config)
@@ -186,7 +190,6 @@ class I18n(ExtendedPlugin):
             if locale == self.current_language:
                 continue
             self.current_language = locale
-            log.info(f"Building '{locale}' documentation to directory: {config.site_dir}")
             # TODO: reconfigure config here? skip on_config?
             dirty = True if "--dirty" in sys.argv or "--dirtyreload" in sys.argv else False
             build(config, dirty=dirty)

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from jinja2.ext import loopcontrols
 from mkdocs import plugins
-from mkdocs.commands.build import DuplicateFilter, build
+from mkdocs.commands.build import build
 from mkdocs.config.defaults import MkDocsConfig
 from mkdocs.plugins import get_plugin_logger
 from mkdocs.structure.files import Files
@@ -13,6 +13,7 @@ from mkdocs.structure.pages import Page
 
 from mkdocs_static_i18n import folder
 from mkdocs_static_i18n.reconfigure import ExtendedPlugin
+from mkdocs_static_i18n.utils import i18nLoggingFilter
 
 log = get_plugin_logger(__name__)
 
@@ -158,14 +159,9 @@ class I18n(ExtendedPlugin):
         self.building = True
 
         # Block time logging for internal builds
-        try:
-            duplicate_filter: DuplicateFilter = logging.getLogger("mkdocs.commands.build").filters[
-                0
-            ]
-            duplicate_filter.msgs.add("Documentation built in %.2f seconds")
-        except IndexError:
-            # tests dont setup a duplicatefilter
-            pass
+        build_logger = logging.getLogger("mkdocs.commands.build")
+        i18n_filter = i18nLoggingFilter()
+        build_logger.addFilter(i18n_filter)
 
         # manually trigger with-pdf, see #110
         with_pdf_plugin = config.plugins.get("with-pdf")
@@ -204,9 +200,6 @@ class I18n(ExtendedPlugin):
         utils.clean_directory = mkdocs_utils_clean_directory
 
         # Unblock time logging after internal builds
-        try:
-            duplicate_filter.msgs.remove("Documentation built in %.2f seconds")
-        except UnboundLocalError:
-            # tests dont setup a duplicatefilter
-            pass
+        build_logger.removeFilter(i18n_filter)
+
         self.building = False

--- a/mkdocs_static_i18n/reconfigure.py
+++ b/mkdocs_static_i18n/reconfigure.py
@@ -356,7 +356,7 @@ class ExtendedPlugin(BasePlugin[I18nPluginConfig]):
                     log.info(
                         f"Adding '{language}' to the '{search_plugin_name}' plugin 'lang' option"
                     )
-            else:
+            elif language == self.current_language:
                 log.info(
                     f"Language '{language}' is not supported by "
                     f"lunr.js, not setting it in the 'plugins.search.lang' option"

--- a/mkdocs_static_i18n/utils.py
+++ b/mkdocs_static_i18n/utils.py
@@ -29,7 +29,7 @@ def get_plugin(name: str, config: MkDocsConfig) -> Optional[Plugin]:
     return None
 
 
-class i18nLoggingFilter:
+class I18nLoggingFilter:
     """Avoid logging duplicate build time messages."""
 
     def __init__(self, *_, **__):

--- a/mkdocs_static_i18n/utils.py
+++ b/mkdocs_static_i18n/utils.py
@@ -1,4 +1,5 @@
-"""Utility functions that aren't limited to any scenario."""
+"""Utility functions and classes that aren't limited to any scenario."""
+import logging
 from typing import Dict, Optional, TypeVar
 
 from mkdocs.config.defaults import MkDocsConfig
@@ -26,3 +27,13 @@ def get_plugin(name: str, config: MkDocsConfig) -> Optional[Plugin]:
             return p
 
     return None
+
+
+class i18nLoggingFilter:
+    """Avoid logging duplicate build time messages."""
+
+    def __init__(self, *_, **__):
+        pass
+
+    def __call__(self, record: logging.LogRecord) -> bool:
+        return not record.msg.startswith("Documentation built in")

--- a/mkdocs_static_i18n/utils.py
+++ b/mkdocs_static_i18n/utils.py
@@ -33,7 +33,11 @@ class i18nLoggingFilter:
     """Avoid logging duplicate build time messages."""
 
     def __init__(self, *_, **__):
-        pass
+        self.filtered_prefixes = set()
 
     def __call__(self, record: logging.LogRecord) -> bool:
-        return not record.msg.startswith("Documentation built in")
+        for prefix in self.filtered_prefixes:
+            if record.msg.startswith(prefix):
+                return False
+
+        return True


### PR DESCRIPTION
MkDocs 1.5 started using f-strings when creating build time log messages, therefore each string is unique (as the time typically changes slightly). 
The old solution stopped working, so now instead I've created a different DuplicateFilter class, which looks at the prefix of the log and not the exact match.
Additionally this PR changes makes more logging changes:
- adds messages about default language being built
- scopes the lunr.js log warning only to the built language