### PR TITLE
refactor(config): Add build_only_locale option

### DIFF
--- a/docs/setup/controlling-your-builds.md
+++ b/docs/setup/controlling-your-builds.md
@@ -90,7 +90,7 @@ The localized (non default) language structure can have files which are not pres
 
 You can control whether you want the plugin to use (fallback to) the default language version of a page or resource when its localized version is missing from the docs structure.
 
-## Option: `fallback_to_default`
+### Option: `fallback_to_default`
 
 |required|default|allowed values|
 |---|---|---|
@@ -167,3 +167,36 @@ plugins:
     ├── topic1
     │   └── index.html
     ```
+
+## Building only one specific locale
+
+You can control if the plugin should build only one single locale. This would decrease build time during development. You can do it setting the `default` and `build` options of each language separately, or you can make use of the `build_only_locale` option and [*environment variables*](https://www.mkdocs.org/user-guide/configuration/#environment-variables) to select the built locale without modifying the `mkdocs.yml` file each time you switch languages.
+
+### Option: `build_only_locale`
+
+|required|default|allowed values|
+|---|---|---|
+|no|None|Language Code|
+
+```yaml
+plugins:
+  - i18n:
+    build_only_locale: !ENV [BUILD_ONLY_LOCALE]
+```
+
+Each operating system or terminal variant has a different way of setting and unsetting environmental variables:
+
+```bash title="Linux (bash)"
+export BUILD_ONLY_LOCALE=en
+unset BUILD_ONLY_LOCALE
+```
+
+```powershell title="Windows Powershell"
+$env:BUILD_ONLY_LOCALE="en"
+$env:BUILD_ONLY_LOCALE=""
+```
+
+```batch title="Windows Command Prompt (cmd)"
+set BUILD_ONLY_LOCALE=en
+set BUILD_ONLY_LOCALE=
+```

--- a/tests/test_languages_option.py
+++ b/tests/test_languages_option.py
@@ -245,3 +245,66 @@ def test_plugin_languages_dual_lang_with_null():
             "site_url": None,
         },
     ]
+
+
+def test_plugin_build_only_locale():
+    mkdocs_config = load_config(
+        "tests/mkdocs.yml",
+        theme={"name": "material"},
+        docs_dir="docs_suffix_structure_two_languages/",
+        plugins={
+            "i18n": {
+                "build_only_locale": "fr",
+                "languages": [
+                    {
+                        "locale": "en",
+                        "name": "english",
+                        "default": True,
+                        "build": True,
+                    },
+                    {
+                        "locale": "fr", 
+                        "name": "français",
+                        "default": False,
+                        "build": False, 
+                    },
+                ],
+            }
+        },
+    )
+    
+    english = mkdocs_config["plugins"]["i18n"].config.languages[0]
+    french = mkdocs_config["plugins"]["i18n"].config.languages[1]
+
+    assert english["default"] == False
+    assert english["build"] == False
+    assert french["default"] == True
+    assert french["build"] == True
+
+
+def test_plugin_build_only_locale_abort():
+    with pytest.raises(Abort):
+        load_config(
+            "tests/mkdocs.yml",
+            theme={"name": "material"},
+            docs_dir="docs_suffix_structure_two_languages/",
+            plugins={
+                "i18n": {
+                    "build_only_locale": "zh",
+                    "languages": [
+                        {
+                            "locale": "en",
+                            "name": "english",
+                            "default": True,
+                            "build": True,
+                        },
+                        {
+                            "locale": "fr", 
+                            "name": "français",
+                            "default": False,
+                            "build": False, 
+                        },
+                    ],
+                }
+            },
+        )


### PR DESCRIPTION
Closes #262 
As discussed, I added a different option that allows to lock the build to a single language using environmental variables.
It's validated in the config class.
I added documentation about it too, I hope it's in the correct place.