### PR TITLE
Fix/folder file lookup

### DIFF
--- a/mkdocs_static_i18n/folder.py
+++ b/mkdocs_static_i18n/folder.py
@@ -138,7 +138,7 @@ class I18nFiles(Files):
             expected_src_uris.append(PurePath(self.plugin.default_language) / expected_src_uri)
         expected_src_uris.append(expected_src_uri)
 
-        for src_uri in expected_src_uris:
+        for src_uri in reversed(expected_src_uris):
             file = self.src_uris.get(src_uri.as_posix())
             if file:
                 return file

--- a/mkdocs_static_i18n/folder.py
+++ b/mkdocs_static_i18n/folder.py
@@ -118,6 +118,11 @@ class I18nFiles(Files):
         # non localized paths detection (root)
         if is_relative_to(expected_src_uri, self.plugin.current_language):
             expected_src_uris.append(expected_src_uri.relative_to(self.plugin.current_language))
+            # default language path detection
+            if self.plugin.config.fallback_to_default is True:
+                expected_src_uris.append(
+                    PurePath(self.plugin.default_language) / expected_src_uris[-1]
+                )
         elif is_relative_to(expected_src_uri, self.plugin.default_language):
             expected_src_uris.append(expected_src_uri.relative_to(self.plugin.default_language))
             if self.plugin.config.fallback_to_default is True:


### PR DESCRIPTION
Fixes #277 

Fixed the obvious issues, but when I wanted to delete this additional fallback path it creates warnings for missing nav files:
```py
        # default language path detection
        if self.plugin.config.fallback_to_default is True:
            expected_src_uris.append(PurePath(self.plugin.default_language) / expected_src_uri)
```
```
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
             - en\api\index.md
             - en\bot\faq.md
             - en\legal\api.md
             - en\legal\bot.md
             - en\legal\website.md
WARNING -  A relative path to 'api/index.md' is included in the 'nav' configuration, which is not found in the documentation files.
WARNING -  A relative path to 'bot/faq.md' is included in the 'nav' configuration, which is not found in the documentation files.
WARNING -  A relative path to 'legal/bot.md' is included in the 'nav' configuration, which is not found in the documentation files.
WARNING -  A relative path to 'legal/api.md' is included in the 'nav' configuration, which is not found in the documentation files.
WARNING -  A relative path to 'legal/website.md' is included in the 'nav' configuration, which is not found in the documentation files.
```
So I kept it around, and therefore it still generates an invalid path sometimes:
```
de-CH/legal/bot.md
en/de-CH/legal/bot.md
en/legal/bot.md
legal/bot.md
```
I don't know what would be a good solution, to avoid any warnings and avoid such `default/current/.../file.md` paths, but for now it's enough to patch it.