### PR TITLE
mkdocs-with-pdf compatibility: trigger on_config()

### DIFF
--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -46,7 +46,16 @@ class I18n(ExtendedPlugin):
         )
 
         # reconfigure the mkdocs config
-        return self.reconfigure_mkdocs_config(config)
+        config = self.reconfigure_mkdocs_config(config)
+        
+        # manually trigger with-pdf, to apply language specific overrides
+        with_pdf_plugin = config.plugins.get("with-pdf")
+        if with_pdf_plugin:
+            config = with_pdf_plugin.on_config(config)
+        
+        return config
+    
+    
 
     @plugins.event_priority(-100)
     def on_files(self, files: Files, config: MkDocsConfig):


### PR DESCRIPTION
This adds a manual trigger to `with_pdf_plugin.on_config(config)` to this plugins' `on_config()` handler, which allows the `site_name` user override to propagate to the [cover_title](https://github.com/orzih/mkdocs-with-pdf/blob/ccf20e5a12d57ca6a474faaaac849cf60fb1fab7/mkdocs_with_pdf/options.py#L71) in the generated PDF