### PR TITLE
Load user overrides from PO file

### DIFF
--- a/mkdocs_static_i18n/config.py
+++ b/mkdocs_static_i18n/config.py
@@ -84,9 +84,7 @@ class I18nPoOverridesConfig(Config):
     """configure the user overrides which should be read from a po file"""
 
     po_dir = config_options.Type(str, default="")
-    override = config_options.Optional(
-        config_options.ListOfItems(config_options.Type(str))
-    )
+    override = config_options.Optional(config_options.ListOfItems(config_options.Type(str)))
 
 
 class I18nPluginConfig(Config):

--- a/mkdocs_static_i18n/config.py
+++ b/mkdocs_static_i18n/config.py
@@ -80,6 +80,15 @@ class I18nPluginLanguage(Config):
         return failed, warnings
 
 
+class I18nPoOverridesConfig(Config):
+    """configure the user overrides which should be read from a po file"""
+
+    po_dir = config_options.Type(str, default="")
+    override = config_options.Optional(
+        config_options.ListOfItems(config_options.Type(str))
+    )
+
+
 class I18nPluginConfig(Config):
     """ """
 
@@ -91,6 +100,7 @@ class I18nPluginConfig(Config):
     languages = config_options.ListOfItems(
         config_options.SubConfig(I18nPluginLanguage, validate=True)
     )
+    po_overrides = config_options.SubConfig(I18nPoOverridesConfig, validate=True)
 
     def validate(self):
         failed, warnings = super().validate()

--- a/mkdocs_static_i18n/reconfigure.py
+++ b/mkdocs_static_i18n/reconfigure.py
@@ -229,7 +229,7 @@ class ExtendedPlugin(BasePlugin[I18nPluginConfig]):
         # read po file if configured and override array is not empty
         if self.config.po_overrides is not None and self.config.po_overrides.override:
             po_file = os.path.normpath(
-                os.path.join(config.config_file_path, self.config.po_overrides, self.current_language + ".po")
+                os.path.join(config.config_file_path, self.config.po_overrides.po_dir, self.current_language + ".po")
             )
             if os.path.exists(po_file):
                 with open(po_file, "r") as fs:

--- a/mkdocs_static_i18n/reconfigure.py
+++ b/mkdocs_static_i18n/reconfigure.py
@@ -250,7 +250,12 @@ class ExtendedPlugin(BasePlugin[I18nPluginConfig]):
                         msgid = config[key]
                         translation = catalog.get(msgid)
                         if translation is not None:
-                            overrides[key] = translation.string
+                            if translation.string:
+                                overrides[key] = translation.string
+                            else:
+                                log.warning(
+                                    f"MsgId '{msgid}' is not translated, discarding override"
+                                )
                         else:
                             log.warning(
                                 f"MsgId '{msgid}' for config '{key}' not found in catalog '{po_file}'"

--- a/mkdocs_static_i18n/reconfigure.py
+++ b/mkdocs_static_i18n/reconfigure.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from copy import deepcopy
-from os import path
+import os.path
 from pathlib import Path, PurePath
 from typing import Union
 from urllib.parse import urlsplit
@@ -228,8 +228,10 @@ class ExtendedPlugin(BasePlugin[I18nPluginConfig]):
         overrides = dict()
         # read po file if configured and override array is not empty
         if self.config.po_overrides is not None and self.config.po_overrides.override:
-            po_file = path.join(self.config.po_overrides, self.current_language + ".po")
-            if path.exists(po_file):
+            po_file = os.path.normpath(
+                os.path.join(config.config_file_path, self.config.po_overrides, self.current_language + ".po")
+            )
+            if os.path.exists(po_file):
                 with open(po_file, "r") as fs:
                     catalog = pofile.read_po(fs)
 


### PR DESCRIPTION
Hi, this is a proposal for adding the functionality to load user overrides from a gettext po file rather than specifying them explicitly in the config file.

In the current draft, this adds the following options to the plugin config:

```yaml
plugins: 
  - i18n:
      po_overrides:
        po_dir: locale
        override: [site_name]
```

where `po_dir` is the directory path relative to the directory containing the config file where the po files are located, and `override` is an array of config keys to override.

For each configured language it looks for a file `<locale>.po` (i.e. `en.po`) in `po_dir`, reads the original value of the elements specified in `override` and tries to find a translation for them in the po file (msgid = original config value). If found, the translation is used as override value.

If an explicit override is configured for the language, the explicit one takes precedence.

## Rationale

I'm using mkdocs to construct a system for building "operating manuals" for special-purpose machinery, which has to be handed out in the manufacturers language ("original"), but as well in the national language of the country where it is deployed ("translation") and which has to be clearly marked as translation.

The idea is to have a "template" repository which is forked for each new project so that the people doing documentation have as few contact with the inner works of the project structure and build system as possible.

Translation is to be done half-automatically, using a similar approach like [mkdocs-mdpo-plugin](https://github.com/mondeja/mkdocs-mdpo-plugin) but purpose built (currently not a mkdocs plugin), which then generates the translated sources from po-files previously extracted from the default language files.

Loading the overrides from the po files allows me to

* Move stuff like `site_name`, which is content in my opinion, out of the configuration
* Lets me automatically generate a translation for it when a user adds a new language (which potentially happens for each new project)
* Lets me change the default languages title to "operating manual - original" despite the automatic translation (by hardcoding that one in the config)

## ToDo

This is still in a draft state which currently works for my special purpose, but propably needs some edge case testing and polishing for general useability. If you're interested in merging, I'll try to invest some more time to add tests, proper docs, etc.
 



