### PR TITLE
Added admonitions translations to `pymdownx.details`

### DIFF
--- a/docs/setup/translating-content.md
+++ b/docs/setup/translating-content.md
@@ -58,6 +58,10 @@ plugins:
         admonition_translations:
           - tip: Conseil
           - warning: Avertissement
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
 ```
 
 and translates French markdowns:

--- a/docs/setup/translating-content.md
+++ b/docs/setup/translating-content.md
@@ -38,6 +38,10 @@ It works the same for the `folder` structure!
 
 This sub-option is a key/value mapping set per language and allows you to translate [admonition](https://python-markdown.github.io/extensions/admonition/) titles which don't have an explicit title defined.
 
+Also, this configuration will apply to [PyMdown Details Extension][details], if the extension is enabled.
+
+[details]: https://facelessuser.github.io/pymdown-extensions/extensions/details/
+
 ### Language Sub-Option: `admonition_translations`
 
 This example overrides admonition titles of the French version of the site.
@@ -56,18 +60,55 @@ plugins:
           - warning: Avertissement
 ```
 
-and translates French markdowns from:
+and translates French markdowns:
 
-```
-!!! tip
+=== "admonitions"
+    From:
 
-    Bonjour le monde
-```
+    ```
+    !!! tip
 
-to:
+        Bonjour le monde
+    ```
 
-```
-!!! tip "Conseil"
+    to:
 
-    Bonjour le monde
-```
+    ```
+    !!! tip "Conseil"
+
+        Bonjour le monde
+    ```
+
+=== "details"
+    From:
+
+    ```
+    ??? tip
+
+        Bonjour le monde
+    ```
+
+    to:
+
+    ```
+    ??? tip "Conseil"
+
+        Bonjour le monde
+    ```
+
+=== "details (open)"
+    From:
+
+    ```
+    ???+ tip
+
+        Bonjour le monde
+    ```
+
+    to:
+
+    ```
+    ???+ tip "Conseil"
+
+        Bonjour le monde
+    ```

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -157,7 +157,7 @@ class I18n(ExtendedPlugin):
 
         marker = r"!{3}"  # Admonition marker
         if "pymdownx.details" in config["markdown_extensions"]:
-            marker = r"(?:\?{3}|!{3})"  # Admonition or Details marker
+            marker = r"(?:\?{3}\+?|!{3})"  # Admonition or Details marker
 
         RE = re.compile(
             r'^('

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -159,12 +159,9 @@ class I18n(ExtendedPlugin):
         if "pymdownx.details" in config["markdown_extensions"]:
             marker = r"(?:\?{3}\+?|!{3})"  # Admonition or Details marker
 
-        RE = re.compile(
-            r'^('
-            + marker
-            + r' ?)([\w\-]+(?: +[\w\-]+)*)(?: +"(.*?)")? *$'
-        )   # Copied from https://github.com/Python-Markdown/markdown/blob/master/markdown/extensions/admonition.py and modified for a single-line processing
-            # Adapted to match the details extension as well
+        # Copied from https://github.com/Python-Markdown/markdown/blob/master/markdown/extensions/admonition.py and modified for a single-line processing
+        # Adapted to match the details extension as well
+        RE = re.compile('^(' + marker + r' ?)([\w\-]+(?: +[\w\-]+)*)(?: +"(.*?)")? *$')
 
         def handle_admonition_translations(line):
             m = RE.match(line)

--- a/mkdocs_static_i18n/plugin.py
+++ b/mkdocs_static_i18n/plugin.py
@@ -155,25 +155,19 @@ class I18n(ExtendedPlugin):
         """
         admonition_translations = self.current_language_config.admonition_translations or {}
 
-        RE_ADMONITION = re.compile(
-            r'^(!!! ?)([\w\-]+(?: +[\w\-]+)*)(?: +"(.*?)")? *$'
-        )  # Copied from https://github.com/Python-Markdown/markdown/blob/master/markdown/extensions/admonition.py and modified for a single-line processing
-        def handle_admonition_translations(line):
-            m = RE_ADMONITION.match(line)
-            if m:
-                type = m.group(2)
-                if (
-                    m.group(3) is None or m.group(3).strip() == ''
-                ) and type in admonition_translations:
-                    title = admonition_translations[type]
-                    line = m.group(1) + m.group(2) + f' "{title}"'
-            return line
+        marker = r"!{3}"  # Admonition marker
+        if "pymdownx.details" in config["markdown_extensions"]:
+            marker = r"(?:\?{3}|!{3})"  # Admonition or Details marker
 
-        RE_DETAILS = re.compile(
-            r'^(\?\?\? ?)([\w\-]+(?: +[\w\-]+)*)(?: +"(.*?)")? *$'
-        )  # Copied from https://github.com/Python-Markdown/markdown/blob/master/markdown/extensions/admonition.py and modified for a single-line processing
-        def handle_details_translations(line):
-            m = RE_DETAILS.match(line)
+        RE = re.compile(
+            r'^('
+            + marker
+            + r' ?)([\w\-]+(?: +[\w\-]+)*)(?: +"(.*?)")? *$'
+        )   # Copied from https://github.com/Python-Markdown/markdown/blob/master/markdown/extensions/admonition.py and modified for a single-line processing
+            # Adapted to match the details extension as well
+
+        def handle_admonition_translations(line):
+            m = RE.match(line)
             if m:
                 type = m.group(2)
                 if (
@@ -186,8 +180,6 @@ class I18n(ExtendedPlugin):
         out = []
         for line in markdown.splitlines():
             line = handle_admonition_translations(line)
-            if "pymdownx.details" in config["markdown_extensions"]:
-                line = handle_details_translations(line)
             out.append(line)
 
         markdown = "\n".join(out)

--- a/tests/details/index.fr.md
+++ b/tests/details/index.fr.md
@@ -6,6 +6,12 @@
 ???tip
     Pareil sans espaces
 
+???+ tip
+    Same but opened by default
+
+???+tip
+    Same without space
+
 ??? warning
     Titre implicite dérivé du type d'avertissement, peut être remplacé en définissant `admonition_translations`
 

--- a/tests/details/index.fr.md
+++ b/tests/details/index.fr.md
@@ -1,0 +1,13 @@
+# Page d'accueil (french version)
+
+??? tip
+    Titre implicite dérivé du type d'avertissement, peut être remplacé en définissant `admonition_translations`
+
+???tip
+    Pareil sans espaces
+
+??? warning
+    Titre implicite dérivé du type d'avertissement, peut être remplacé en définissant `admonition_translations`
+
+??? warning "Heey"
+    Titre explicite, n'est pas traduit par `admonition_translations`

--- a/tests/details/index.md
+++ b/tests/details/index.md
@@ -6,6 +6,12 @@
 ???tip
     Same without space
 
+???+ tip
+    Same but opened by default
+
+???+tip
+    Same without space
+
 ??? warning
     Implicit title derived from admonition type, can be overriden by setting `admonition_translations`
 

--- a/tests/details/index.md
+++ b/tests/details/index.md
@@ -1,0 +1,13 @@
+# Home page
+
+??? tip
+    Implicit title derived from admonition type, can be overriden by setting `admonition_translations`
+
+???tip
+    Same without space
+
+??? warning
+    Implicit title derived from admonition type, can be overriden by setting `admonition_translations`
+
+??? warning "Heey"
+    Explicit title, isn't translated by `admonition_translations`

--- a/tests/test_details.py
+++ b/tests/test_details.py
@@ -1,0 +1,46 @@
+import re
+import logging
+from pathlib import Path
+
+from mkdocs.commands.build import build
+from mkdocs.config.base import load_config
+
+def test_plugin_no_use_directory_urls_default_language_only():
+    mkdocs_config = load_config(
+        "tests/mkdocs.yml",
+        theme={"name": "material"},
+        docs_dir="details/",
+        plugins={
+            "i18n": {
+                "languages": [
+                    {
+                        "locale": "en",
+                        "name": "english",
+                        "default": True,
+                    },
+                    {
+                        "locale": "fr",
+                        "name": "français",
+                        "build": True,
+                        "admonition_translations": {
+                            "tip": "Conseil",
+                            "warning": "Avertissement",
+                        }
+                    },
+                ],
+            },
+        },
+        markdown_extensions=["admonition", "pymdownx.details"],
+    )
+
+    build(mkdocs_config)
+
+    site_dir = mkdocs_config["site_dir"]
+
+    with open(site_dir+'/index.html') as f:
+        admonition_titles = re.findall(r"<summary>([^<]*)", f.read())
+        assert(admonition_titles == ['Tip', 'Tip', 'Warning', 'Heey'])
+
+    with open(site_dir+'/fr/index.html') as f:
+        admonition_titles = re.findall(r"<summary>([^<]*)", f.read())
+        assert(admonition_titles == ['Conseil', 'Conseil', 'Avertissement', 'Heey'])

--- a/tests/test_details.py
+++ b/tests/test_details.py
@@ -39,8 +39,8 @@ def test_plugin_no_use_directory_urls_default_language_only():
 
     with open(site_dir+'/index.html') as f:
         admonition_titles = re.findall(r"<summary>([^<]*)", f.read())
-        assert(admonition_titles == ['Tip', 'Tip', 'Warning', 'Heey'])
+        assert(admonition_titles == ['Tip', 'Tip', 'Tip', 'Tip', 'Warning', 'Heey'])
 
     with open(site_dir+'/fr/index.html') as f:
         admonition_titles = re.findall(r"<summary>([^<]*)", f.read())
-        assert(admonition_titles == ['Conseil', 'Conseil', 'Avertissement', 'Heey'])
+        assert(admonition_titles == ['Conseil', 'Conseil', 'Conseil', 'Conseil', 'Avertissement', 'Heey'])


### PR DESCRIPTION
[Material for MkDocs](https://squidfunk.github.io/mkdocs-material/reference/admonitions/) includes a way to use a collapsable admonition with `???` syntax, provided by `pymdownx.details` extension.

This PR allows to translate details blocks using the already defined admonitions translations.