### PR TITLE
feat: default in subdirectory option

### DIFF
--- a/docs/setup/controlling-your-builds.md
+++ b/docs/setup/controlling-your-builds.md
@@ -200,3 +200,54 @@ $env:BUILD_ONLY_LOCALE=""
 set BUILD_ONLY_LOCALE=en
 set BUILD_ONLY_LOCALE=
 ```
+
+## Forcing default language into a subdirectory
+
+By default, the default language is built at the root of the site (`/`), while other languages are built in their own subdirectories (e.g. `/en/`, `/fr/`). 
+
+If you want to keep a consistent structure and have all languages, including the default one, in their own subdirectories, you can use the `force_default_in_subdirectory` option.
+
+### Option: `force_default_in_subdirectory`
+
+|required|default|allowed values|
+|---|---|---|
+|no|false| true \| false|
+
+``` yaml
+plugins:
+  - i18n:
+    force_default_in_subdirectory: true
+```
+
+===  "force_default_in_subdirectory: false (default)"
+    ```
+    docs_dir
+    ├── index.fr.md
+    ├── index.en.md (default language)
+    ```
+
+    will build:
+
+    ```
+    site
+    ├── fr
+    │   └── index.html
+    └── index.html  # from the default language
+    ```
+
+=== "force_default_in_subdirectory: true"
+    ```
+    docs_dir
+    ├── index.fr.md
+    ├── index.en.md (default language)
+    ```
+
+    will build:
+
+    ```
+    site
+    ├── fr
+    │   └── index.html
+    ├── en           # default language is now in subdirectory
+    │   └── index.html
+    ```

--- a/mkdocs_static_i18n/config.py
+++ b/mkdocs_static_i18n/config.py
@@ -46,9 +46,13 @@ class I18nPluginLanguage(Config):
 
     def validate(self):
         failed, warnings = super().validate()
+        # get parent config if available
+        parent_config = getattr(self, '_parent', None)
+        force_subdirectory = parent_config and getattr(parent_config, 'force_default_in_subdirectory', False)
+        
         # set defaults
         if self.link is None:
-            if self.default:
+            if self.default and not force_subdirectory:
                 self.link = "/"
             else:
                 self.link = f"/{self.locale}/"
@@ -86,6 +90,7 @@ class I18nPluginConfig(Config):
     build_only_locale = config_options.Optional(Locale(str))
     docs_structure = config_options.Choice(["folder", "suffix"], default="suffix")
     fallback_to_default = config_options.Type(bool, default=True)
+    force_default_in_subdirectory = config_options.Type(bool, default=False)
     reconfigure_material = config_options.Type(bool, default=True)
     reconfigure_search = config_options.Type(bool, default=True)
     languages = config_options.ListOfItems(

--- a/mkdocs_static_i18n/folder.py
+++ b/mkdocs_static_i18n/folder.py
@@ -18,6 +18,7 @@ def create_i18n_file(
     default_language: str,
     all_languages: list,
     config: MkDocsConfig,
+    force_default_in_subdirectory: bool = False,
 ) -> File:
     log.debug(f"reconfigure {file}")
 
@@ -53,7 +54,7 @@ def create_i18n_file(
     if file_dest_path.name.endswith("README.html"):
         file_dest_path = file_dest_path.with_name("index.html")
 
-    if file_locale != current_language:
+    if file_locale != current_language or force_default_in_subdirectory:
         if is_relative_to(file_dest_path, file_locale):
             # we have to change the output folder
             file.dest_path = PurePath(

--- a/mkdocs_static_i18n/reconfigure.py
+++ b/mkdocs_static_i18n/reconfigure.py
@@ -544,6 +544,7 @@ class ExtendedPlugin(BasePlugin[I18nPluginConfig]):
                     self.default_language,
                     self.all_languages,
                     mkdocs_config,
+                    self.config.force_default_in_subdirectory,
                 )
 
                 # user provided documentation page
@@ -623,6 +624,7 @@ class ExtendedPlugin(BasePlugin[I18nPluginConfig]):
                                 self.default_language,
                                 self.all_languages,
                                 mkdocs_config,
+                                self.config.force_default_in_subdirectory,
                             )
                             i18n_src_uris[i18n_file.norm_src_uri] = i18n_asset
                             log.debug(
@@ -678,6 +680,7 @@ class ExtendedPlugin(BasePlugin[I18nPluginConfig]):
                             self.default_language,
                             self.all_languages,
                             mkdocs_config,
+                            self.config.force_default_in_subdirectory,
                         )
                         if alternate_file.locale == build_lang:
                             i18n_file.alternates[alternate_file.locale] = alternate_file
@@ -693,6 +696,7 @@ class ExtendedPlugin(BasePlugin[I18nPluginConfig]):
                                     self.default_language,
                                     self.all_languages,
                                     mkdocs_config,
+                                    self.config.force_default_in_subdirectory,
                                 )
                                 if alternate_file.locale == self.default_language:
                                     i18n_file.alternates[build_lang] = alternate_file
@@ -704,6 +708,7 @@ class ExtendedPlugin(BasePlugin[I18nPluginConfig]):
                                     self.default_language,
                                     self.all_languages,
                                     mkdocs_config,
+                                    self.config.force_default_in_subdirectory,
                                 )
                                 if alternate_file.locale == self.default_language:
                                     i18n_file.alternates[build_lang] = alternate_file
@@ -742,6 +747,7 @@ class ExtendedPlugin(BasePlugin[I18nPluginConfig]):
                     self.default_language,
                     self.all_languages,
                     mkdocs_config,
+                    self.config.force_default_in_subdirectory,
                 )
                 # used to rebuild blog alternates for the sitemap.xml and language switcher
                 i18n_src_uris[i18n_file.norm_src_uri] = file

--- a/mkdocs_static_i18n/suffix.py
+++ b/mkdocs_static_i18n/suffix.py
@@ -18,6 +18,7 @@ def create_i18n_file(
     default_language: str,
     all_languages: list,
     config: MkDocsConfig,
+    force_default_in_subdirectory: bool = False,
 ) -> File:
     log.debug(f"reconfigure {file}")
 
@@ -34,7 +35,7 @@ def create_i18n_file(
     file_dest_path = Path(file.dest_path)
     file_locale = default_language
     file_localization = None
-    locale_site_dir = current_language if current_language != default_language else ""
+    locale_site_dir = current_language if current_language != default_language or force_default_in_subdirectory else ""
 
     try:
         file_locale = Path(file.name).suffixes.pop(-1).replace(".", "")

--- a/tests/test_force_default_in_subdirectory.py
+++ b/tests/test_force_default_in_subdirectory.py
@@ -1,0 +1,234 @@
+from pathlib import Path
+
+import pytest
+from mkdocs.commands.build import build
+from mkdocs.config.base import load_config
+
+# Folder structure test cases
+FOLDER_NO_USE_DIRECTORY_URLS = [
+    Path("404.html"),
+    Path("assets/image_non_localized.png"),
+    Path("english_default/index.html"),
+    Path("image.fake"),
+    Path("image.png"),
+    Path("index.html"),
+    Path("topic1/named_file.html"),
+    Path("topic2/1.1.filename.html"),
+    Path("topic2/index.html"),
+    Path("topic2/release_notes_17.1.html"),
+    Path("topic2/release_notes_17.2.html"),
+    Path("fr/english_default/index.html"),
+    Path("fr/french_only/index.html"),
+    Path("fr/image.fake"),
+    Path("fr/image.png"),
+    Path("fr/index.html"),
+    Path("fr/topic1/named_file.html"),
+    Path("fr/topic2/1.1.filename.html"),
+    Path("fr/topic2/index.html"),
+    Path("fr/topic2/release_notes_17.1.html"),
+    Path("fr/topic2/release_notes_17.2.html"),
+]
+
+# Test cases for force_default_in_subdirectory=True
+FOLDER_FORCE_DEFAULT_USE_DIRECTORY_URLS = [
+    Path("404.html"),
+    Path("assets/image_non_localized.png"),
+    Path("en/english_default/index.html"),
+    Path("en/image.fake"),
+    Path("en/image.png"),
+    Path("en/index.html"),
+    Path("en/topic1/named_file/index.html"),
+    Path("en/topic2/1.1.filename.html"),
+    Path("en/topic2/index.html"),
+    Path("en/topic2/release_notes_17.1/index.html"),
+    Path("en/topic2/release_notes_17.2/index.html"),
+    Path("fr/english_default/index.html"),
+    Path("fr/french_only/index.html"),
+    Path("fr/image.fake"),
+    Path("fr/image.png"),
+    Path("fr/index.html"),
+    Path("fr/topic1/named_file/index.html"),
+    Path("fr/topic2/1.1.filename.html"),
+    Path("fr/topic2/index.html"),
+    Path("fr/topic2/release_notes_17.1/index.html"),
+    Path("fr/topic2/release_notes_17.2/index.html"),
+]
+
+# Suffix structure test cases
+SUFFIX_NO_USE_DIRECTORY_URLS = [
+    Path("english_default/index.html"),
+    Path("404.html"),
+    Path("image.png"),
+    Path("image.fake"),
+    Path("index.html"),
+    Path("assets/image_non_localized.png"),
+    Path("topic1/named_file.html"),
+    Path("topic2/index.html"),
+    Path("topic2/1.1.filename.html"),
+    Path("topic2/release_notes_17.1.html"),
+    Path("topic2/release_notes_17.2.html"),
+    Path("fr/index.html"),
+    Path("fr/image.png"),
+    Path("fr/image.fake"),
+    Path("fr/english_default/index.html"),
+    Path("fr/topic1/named_file.html"),
+    Path("fr/topic2/index.html"),
+    Path("fr/topic2/1.1.filename.html"),
+    Path("fr/french_only/index.html"),
+    Path("fr/topic2/release_notes_17.1.html"),
+    Path("fr/topic2/release_notes_17.2.html"),
+]
+
+SUFFIX_FORCE_DEFAULT_USE_DIRECTORY_URLS = [
+    Path("404.html"),
+    Path("en/assets/image_non_localized.png"),
+    Path("en/english_default/index.html"),
+    Path("en/image.fake"),
+    Path("en/image.png"),
+    Path("en/index.html"),
+    Path("en/topic1/named_file/index.html"),
+    Path("en/topic2/1.1.filename.html"),
+    Path("en/topic2/index.html"),
+    Path("en/topic2/release_notes_17.1/index.html"),
+    Path("en/topic2/release_notes_17.2/index.html"),
+    Path("fr/english_default/index.html"),
+    Path("fr/french_only/index.html"),
+    Path("fr/image.fake"),
+    Path("fr/image.png"),
+    Path("fr/index.html"),
+    Path("fr/topic1/named_file/index.html"),
+    Path("fr/topic2/1.1.filename.html"),
+    Path("fr/topic2/index.html"),
+    Path("fr/topic2/release_notes_17.1/index.html"),
+    Path("fr/topic2/release_notes_17.2/index.html"),
+]
+
+# Folder structure tests
+def test_folder_force_default_use_directory_urls():
+    mkdocs_config = load_config(
+        "tests/mkdocs.yml",
+        theme={"name": "mkdocs"},
+        use_directory_urls=True,
+        docs_dir="docs_folder_structure_two_languages/",
+        plugins={
+            "search": {},
+            "i18n": {
+                "docs_structure": "folder",
+                "force_default_in_subdirectory": True,
+                "languages": [
+                    {
+                        "locale": "en",
+                        "name": "english",
+                        "default": True,
+                    },
+                    {"locale": "fr", "name": "français"},
+                ],
+            },
+        },
+        strict=True,
+    )
+    try:
+        build(mkdocs_config)
+    except Exception as err:
+        pytest.fail(reason=err)
+    site_dir = mkdocs_config["site_dir"]
+    generate_site = [f.relative_to(site_dir) for f in Path(site_dir).glob("**/*.html")]
+    generate_site.extend([f.relative_to(site_dir) for f in Path(site_dir).glob("**/image*.*")])
+    assert sorted(generate_site) == sorted(FOLDER_FORCE_DEFAULT_USE_DIRECTORY_URLS)
+
+def test_folder_force_default_no_use_directory_urls():
+    mkdocs_config = load_config(
+        "tests/mkdocs.yml",
+        theme={"name": "mkdocs"},
+        use_directory_urls=False,
+        docs_dir="docs_folder_structure_two_languages/",
+        plugins={
+            "search": {},
+            "i18n": {
+                "docs_structure": "folder",
+                "force_default_in_subdirectory": False,
+                "languages": [
+                    {
+                        "locale": "en",
+                        "name": "english",
+                        "default": True,
+                    },
+                    {"locale": "fr", "name": "français"},
+                ],
+            },
+        },
+        strict=True,
+    )
+    try:
+        build(mkdocs_config)
+    except Exception as err:
+        pytest.fail(reason=err)
+    site_dir = mkdocs_config["site_dir"]
+    generate_site = [f.relative_to(site_dir) for f in Path(site_dir).glob("**/*.html")]
+    generate_site.extend([f.relative_to(site_dir) for f in Path(site_dir).glob("**/image*.*")])
+    assert sorted(generate_site) == sorted(FOLDER_NO_USE_DIRECTORY_URLS)
+
+# Suffix structure tests
+def test_suffix_force_default_use_directory_urls():
+    mkdocs_config = load_config(
+        "tests/mkdocs.yml",
+        theme={"name": "mkdocs"},
+        use_directory_urls=True,
+        docs_dir="docs_suffix_structure_two_languages/",
+        plugins={
+            "search": {},
+            "i18n": {
+                "docs_structure": "suffix",
+                "force_default_in_subdirectory": True,
+                "languages": [
+                    {
+                        "locale": "en",
+                        "name": "english",
+                        "default": True,
+                    },
+                    {"locale": "fr", "name": "français"},
+                ],
+            },
+        },
+        strict=True,
+    )
+    try:
+        build(mkdocs_config)
+    except Exception as err:
+        pytest.fail(reason=err)
+    site_dir = mkdocs_config["site_dir"]
+    generate_site = [f.relative_to(site_dir) for f in Path(site_dir).glob("**/*.html")]
+    generate_site.extend([f.relative_to(site_dir) for f in Path(site_dir).glob("**/image*.*")])
+    assert sorted(generate_site) == sorted(SUFFIX_FORCE_DEFAULT_USE_DIRECTORY_URLS)
+
+def test_suffix_force_default_no_use_directory_urls():
+    mkdocs_config = load_config(
+        "tests/mkdocs.yml",
+        theme={"name": "mkdocs"},
+        use_directory_urls=False,
+        docs_dir="docs_suffix_structure_two_languages/",
+        plugins={
+            "search": {},
+            "i18n": {
+                "docs_structure": "suffix",
+                "force_default_in_subdirectory": False,
+                "languages": [
+                    {
+                        "locale": "en",
+                        "name": "english",
+                        "default": True,
+                    },
+                    {"locale": "fr", "name": "français"},
+                ],
+            },
+        },
+        strict=True,
+    )
+    try:
+        build(mkdocs_config)
+    except Exception as err:
+        pytest.fail(reason=err)
+    site_dir = mkdocs_config["site_dir"]
+    generate_site = [f.relative_to(site_dir) for f in Path(site_dir).glob("**/*.html")]
+    generate_site.extend([f.relative_to(site_dir) for f in Path(site_dir).glob("**/image*.*")])
+    assert sorted(generate_site) == sorted(SUFFIX_NO_USE_DIRECTORY_URLS)


### PR DESCRIPTION
## Description

This PR addresses problem of broken link/image path due to moving default language to top level. (`/en/` to `/`)

Current PR implementation introduces `force_default_in_subdirectory` config option, which let user to decide moving default language to top level with backward compatibility.

However, this change introduces new configuration option, so I would like to discuss best configuration option.

```
plugins:
  - i18n:
    force_default_in_subdirectory: true
```

Other alternative implementation option:

Alternative Configuration 1: "Move files to the path if `link` config is set to language"

Currently link generated is broken (404 error) since file is moved to top level.
This option is more intuitive but may introduce change to existing user have such configuration.

```
languages:
  - locale: en
    default: true
    link: `/en/`    # Currently link generated is broken since file is moved to top level.
```

## Consideration

**Handling contents without locale info**

This PR implementation have discrepancy between folder configuration and suffix configuration.

For folder configuration, files not under lang folder does not belong to specific language and path is not changed.

```
docs
|- asset/*  # do not move
|- en/*   # default: move to top level `/` or `/en/` with `force_default_in_subdirectory` option
|- fr/*
```

But in suffix configuration, file without suffix is currently treated as default language, so files is moved too.

```
docs
|- *.png,jpg,md    # default: move to top level `/` or `/en/` with `force_default_in_subdirectory` option
|- *.en.md  # default: move to top level `/` or `/en/` with `force_default_in_subdirectory` option
|- *.fr.md
```

Current design of plugin and option introduced by this PR may create discrepancy between folder and suffix configuration.

**Top level path redirection**

I am developing my own site with this branch, and adding index.html which redirects to default language page, but this can possibly done in plugin.

```
# folder structure
docs
|- en/*
|- fr/*
|- index.html
```

```html
# index.html
<!doctype html>
<html>
  <head>
    <meta
      http-equiv="refresh"
      content="0; url=/en/" />
    <link rel="canonical" href="/en/" />
    <title>Redirecting...</title>
  </head>
  <body>
    <p>
      If you are not redirected automatically, please
      <a href="/en/">click here</a>.
    </p>
  </body>
</html>
```

## Related Issue

#306 