### PR TITLE
Fix: Not yet translated files in duplicated navigation entry

### DIFF
--- a/mkdocs_static_i18n/folder.py
+++ b/mkdocs_static_i18n/folder.py
@@ -177,6 +177,14 @@ def merge_structure_items(structure_items):
             merged_structure_items.append(structure_item)
     for item in filter(lambda x: x.is_section, merged_structure_items):
         item.children = merge_structure_items(item.children)
+        # NOTE:
+        # After merging items, child nodes keep their old `parent` reference.
+        # MkDocs relies on a correct parent chain to mark ancestor Sections as active,
+        # which Material uses to set aria-expanded="true".
+        # Without resetting `child.parent = item`, ancestor detection breaks and
+        # navigation sections collapse incorrectly.
+        for child in item.children:
+            child.parent = item
     return merged_structure_items
 
 


### PR DESCRIPTION
This PR fixes [Not yet translated files in duplicated navigation entry](https://github.com/ultrabug/mkdocs-static-i18n/issues/300). 

# root cause

For example, consider the following directory structure:

* docs
    * en
        * S3
            * test1.md
            * test2.md
    * den
        * S3
            * test2.md
            * test3.md

reconfigure_navigation removes the language info from the path, so the nav is modified as follows:

* docs
    * S3
        * test1.md
        * test2.md
    * S3
        * test2.md
        * test3.md

After this, there is no process to merge the same S3 directories, so  nav_item.html in mkdocs-material renders each as a separate item, resulting in the problem you pointed out.

# how to fix

if two sections meet all the following conditions , merge them. 

* has same parent
* same title