### PR TITLE
feat(config): Support ISO 639-2/3 language codes

### DIFF
--- a/mkdocs_static_i18n/config.py
+++ b/mkdocs_static_i18n/config.py
@@ -3,7 +3,23 @@ from re import compile
 from mkdocs.config import config_options
 from mkdocs.config.base import Config, ValidationError
 
-RE_LOCALE = compile(r"(^[a-z]{2}(-[A-Za-z]{4})?(-[A-Z]{2})?$)|(^[a-z]{2}_[A-Z]{2}$)")
+# Language part: ISO 639-1 (2-letter) or 639-2/3 (3-letter)
+RE_LANG = r"[a-z]{2,3}"
+
+# Optional script part (e.g., -Latn)
+RE_SCRIPT = r"(-[A-Za-z]{4})?"
+
+# Optional region part (e.g., -US)
+RE_REGION = r"(-[A-Z]{2})?"
+
+# BCP 47-style pattern: lang-script-region (e.g., 'en', 'en-US', 'gsw', 'sr-Latn-RS')
+RE_BCP_47_STYLE = f"^{RE_LANG}{RE_SCRIPT}{RE_REGION}$"
+
+# Legacy-style pattern: lang_REGION (e.g., 'en_US', 'ast_ES')
+RE_LEGACY_STYLE = f"^{RE_LANG}_[A-Z]{{2}}$"
+
+# Valid locale pattern.
+RE_LOCALE = compile(f"({RE_BCP_47_STYLE})|({RE_LEGACY_STYLE})")
 
 
 class Locale(config_options.Type):

--- a/tests/test_locale_type.py
+++ b/tests/test_locale_type.py
@@ -7,11 +7,16 @@ from mkdocs_static_i18n.config import Locale
 def test_locale_valid_values():
     locale = Locale(str)
     valid_locales = [
-        "en",
+        "en",  # ISO 639-1
         "en-US",
         "en_US",
         "en-GB",
         "en-UK",  # valid pattern, but the territory code is not a valid ISO-3166-1 alpha-2 code
+        "ast",  # ISO 639-2 / 639-3
+        "ast-ES",
+        "ast_ES",
+        "ast-Latn",
+        "ast-Latn-ES",
         "fr",
         "fr-FR",
         "fr_FR",


### PR DESCRIPTION
The locale validation regex is updated to accept 3-letter language codes (e.g. 'ast') in addition to the existing 2-letter codes.

The expression has also been refactored for improved readability.

Fixes: #339